### PR TITLE
Fix Debug builds hanging when loading VPinMAME tables with .NET COM servers

### DIFF
--- a/make/vpx-core.vcxitems
+++ b/make/vpx-core.vcxitems
@@ -299,8 +299,8 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCMT;LIBCD;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <StackReserveSize>0</StackReserveSize>
-      <StackCommitSize>0</StackCommitSize>
+      <StackReserveSize>1048576</StackReserveSize>
+      <StackCommitSize>4096</StackCommitSize>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <LargeAddressAware>true</LargeAddressAware>
@@ -351,8 +351,8 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCMT;LIBCD;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <StackReserveSize>0</StackReserveSize>
-      <StackCommitSize>0</StackCommitSize>
+      <StackReserveSize>1048576</StackReserveSize>
+      <StackCommitSize>4096</StackCommitSize>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <LargeAddressAware>true</LargeAddressAware>
@@ -403,8 +403,8 @@
       <IgnoreSpecificDefaultLibraries>LIBC;LIBCMT;LIBCD;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <StackReserveSize>0</StackReserveSize>
-      <StackCommitSize>0</StackCommitSize>
+      <StackReserveSize>1048576</StackReserveSize>
+      <StackCommitSize>4096</StackCommitSize>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <LargeAddressAware>true</LargeAddressAware>


### PR DESCRIPTION
## Problem

Debug builds (`Debug`, `Debug_GL`, `Debug_BGFX`) hang indefinitely when loading any VPinMAME-backed SS pinball table that uses a .NET-authored COM server (`B2S.Server`, Freezy's `DmdDevice`, `FlexDMD`, etc.). Repro table: Black Pyramid (Bally 1984). Non-VPinMAME tables and pure EM tables load fine.

## Root cause

The three Debug configurations in `make/vpx-core.vcxitems` had:
```xml
<StackReserveSize>0</StackReserveSize>
<StackCommitSize>0</StackCommitSize>
```

This writes literal zeros into the produced exe's PE header `SizeOfStackReserve` / `SizeOfStackCommit` fields (confirmed via `dumpbin /headers`). Release configurations don't set these elements at all, so the linker's 1 MB / 4 KB defaults end up in the PE header — which is why Release has always worked.

## Mechanism

When VPinMAME's worker thread makes its first managed call, the CLR computes default thread-pool limits via:

```
clr!GetDefaultMaxLimitWorkerThreads:
  ...
  lea  rcx, [rsp+20h]
  call clr!Thread::GetProcessDefaultStackSize   ; fills [rsp+20h] from PE header
  ...
  mov  rax, [rsp+58h]                           ; TotalPhysMem
  shr  rax, 1                                   ; / 2
  xor  edx, edx
  div  rax, qword ptr [rsp+20h]                 ; (Memory/2) / stackReserveSize
```

With `SizeOfStackReserve = 0`, the `div` at `+0x51` raises a first-chance integer divide-by-zero (`c0000094`). CLR's SEH catches it and retries forever in `EESleepEx`. The worker thread never signals ready. Meanwhile VPX's main STA is blocked inside `Player::Player → FireVoidEvent(Init) → vbscript → Controller.Run → WaitForMultipleObjects(INFINITE)` waiting for that same worker — classic two-sided deadlock.

CLR `coreclr/src/vm/win32threadpool.cpp` confirms the formula and the absence of a zero-divisor guard.

## Fix

Set Debug configs to the canonical linker defaults (same as Release):
```xml
<StackReserveSize>1048576</StackReserveSize>
<StackCommitSize>4096</StackCommitSize>
```

6 lines changed across 3 sites (Debug, Debug_GL, Debug_BGFX).

## Verification

**Before fix** (`dumpbin /headers VPinballX_BGFX64.exe` for Debug_BGFX):
```
0       size of stack reserve
0       size of stack commit
```

**After fix**:
```
100000  size of stack reserve
1000    size of stack commit
```

Live debug: attached cdb invasively to Debug_BGFX with breakpoints on `clr!ThreadpoolMgr::EnsureInitialized`, `clr!ThreadNative::Start`, and `clr!ThreadpoolMgr::EnsureGateThreadRunning`. Before the fix, the Debug trace showed `(XXXX.YYYY): Integer divide-by-zero - code c0000094 (first chance)` at `clr!GetDefaultMaxLimitWorkerThreads+0x51` immediately after `EnsureInitialized` fired. Release's trace (same breakpoints, same table) showed the breakpoints firing many times without any divide-by-zero.

After the fix, Black Pyramid loads and plays normally in Debug_BGFX. Thread 0 reaches `Player::MultithreadedGameLoop` at `player.cpp:1896` — the same healthy game-loop state as Release. Memory use and thread composition now match the Release run.

## Impact

- Fixes all three Debug configs (DX9, GL, BGFX). No change to Release configs.
- No source code changes — build configuration only.
- No dependencies added or removed.