### PR TITLE
Cut Ball History menu draw cost from ~150 ms/frame to a few ms

### DIFF
--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -850,6 +850,7 @@ BallHistory::BallHistory(PinTable& pinTable)
    , m_BallHistoryRecordsHeadIndex(0)
    , m_BallHistoryRecordsSize(0)
    , m_MaxBallVelocityPixels(0.0f)
+   , m_LastDrawBallHistoryInputsHash(0)
    , m_AutoControlBallColor(Color::Black)
    , m_RecallBallColor(Color::Blue)
    , m_TrainerBallStartColor(Color::Blue)
@@ -2140,6 +2141,23 @@ void BallHistory::DrawBallHistory(Player& player)
 {
    ProfilerRecord::ProfilerScope profilerScope(m_ProfilerRecord.m_DrawBallHistoryUsec);
 
+   // Early-out: if all inputs are unchanged AND we already have drawn parts from the previous
+   // frame, the visual output is identical — those parts are still attached to the table and
+   // will re-render. Skipping the 3-pass walk over the ring buffer (1500-8000 iterations × pass)
+   // is the bulk of the per-frame cost when the user is just sitting on the menu.
+   {
+      uint64_t h = 1469598103934665603ULL; // FNV-1a basis
+      auto mix = [&](uint64_t v) { h ^= v; h *= 1099511628211ULL; };
+      mix((uint64_t)m_CurrentControlIndex);
+      mix((uint64_t)m_BallHistoryRecordsHeadIndex);
+      mix((uint64_t)m_BallHistoryRecordsSize);
+      mix((uint64_t)m_BallHistoryRecords.size());
+      union { float f; uint32_t u; } v; v.f = m_MaxBallVelocityPixels; mix((uint64_t)v.u);
+      if (h == m_LastDrawBallHistoryInputsHash && (!m_DrawnLines.empty() || !m_DrawnBalls.empty()))
+         return;
+      m_LastDrawBallHistoryInputsHash = h;
+   }
+
    struct DrawBallHistoryRecord
    {
       float TotalDistancePixelsTraveled;
@@ -2345,6 +2363,23 @@ void BallHistory::DrawLine(Player& player, const std::string& name, const Vertex
    if (lineLength == 0.0f)
       return;
 
+   // Fast path: if a line by this name already exists with identical geometry/color/thickness,
+   // its GPU buffers are still valid — skip the entire mutate + RenderRelease + RenderSetup path.
+   {
+      auto cacheIt = m_DrawnLinesGeomCache.find(name);
+      auto lineIt = m_DrawnLines.find(name);
+      if (cacheIt != m_DrawnLinesGeomCache.end() && lineIt != m_DrawnLines.end())
+      {
+         const DrawnLineGeom& prev = cacheIt->second;
+         if (prev.m_PosA.x == posA.x && prev.m_PosA.y == posA.y && prev.m_PosA.z == posA.z
+          && prev.m_PosB.x == posB.x && prev.m_PosB.y == posB.y && prev.m_PosB.z == posB.z
+          && prev.m_Color == color && prev.m_Thickness == thickness)
+         {
+            return;
+         }
+      }
+   }
+
    // Ensure a 1x1 texture exists for this color (reused by name)
    const std::string imageColorName = "BallHistoryDrawLine" + std::to_string(color);
    if (player.m_ptable->GetImage(imageColorName) == nullptr)
@@ -2428,6 +2463,8 @@ void BallHistory::DrawLine(Player& player, const std::string& name, const Vertex
          pLine->RenderSetup(g_pplayer->m_renderer->m_renderDevice);
       });
    }
+
+   m_DrawnLinesGeomCache[name] = { posA, posB, color, thickness };
 }
 
 void BallHistory::DrawIntersectionCircle(Player& player, const std::string& name, Vertex3Ds& position, float intersectionRadiusPercent, DWORD color)
@@ -2436,6 +2473,21 @@ void BallHistory::DrawIntersectionCircle(Player& player, const std::string& name
    if (position2D.x < 0.0f || position2D.y < 0.0f || position2D.x > player.m_playfieldWnd->GetWidth() || position2D.y > player.m_playfieldWnd->GetHeight())
    {
       return;
+   }
+
+   // Fast path: same params as last frame → existing GPU resources are still valid, skip everything.
+   {
+      auto cacheIt = m_DrawnIntersectionCirclesGeomCache.find(name);
+      auto circleIt = m_DrawnIntersectionCircles.find(name);
+      if (cacheIt != m_DrawnIntersectionCirclesGeomCache.end() && circleIt != m_DrawnIntersectionCircles.end())
+      {
+         const DrawnCircleGeom& prev = cacheIt->second;
+         if (prev.m_Position.x == position.x && prev.m_Position.y == position.y && prev.m_Position.z == position.z
+          && prev.m_IntersectionRadiusPercent == intersectionRadiusPercent && prev.m_Color == color)
+         {
+            return;
+         }
+      }
    }
 
    CComObject<Light>* pIntersectionCircle = nullptr;
@@ -2483,6 +2535,8 @@ void BallHistory::DrawIntersectionCircle(Player& player, const std::string& name
          pIntersectionCircle->RenderSetup(g_pplayer->m_renderer->m_renderDevice);
       });
    }
+
+   m_DrawnIntersectionCirclesGeomCache[name] = { position, intersectionRadiusPercent, color };
 }
 
 void BallHistory::DrawControlVBalls(Player &player)
@@ -2577,6 +2631,10 @@ void BallHistory::ClearDraws(Player& player)
          drawnLines.second->Release();
    }
    m_DrawnLines.clear();
+
+   m_DrawnLinesGeomCache.clear();
+   m_DrawnIntersectionCirclesGeomCache.clear();
+   m_LastDrawBallHistoryInputsHash = 0;
 }
 
 bool BallHistory::ShouldDrawTrainerBallStarts(std::size_t index, int currentTimeMs)
@@ -4151,7 +4209,16 @@ void BallHistory::ProcessMenu(Player& player, MenuOptionsRecord::MenuActionType 
    BHLOG("menuAction=%d menuState=%d modeType=%d timeMs=%d", menuAction, m_MenuOptions.m_MenuState, m_MenuOptions.m_ModeType, currentTimeMs);
    ProfilerRecord::ProfilerScope profilerScope(m_ProfilerRecord.m_ProcessMenuUsec);
 
-   ClearDraws(player);
+   // ClearDraws tears down every cached Rubber/Light/Ball part (RenderRelease + RemovePart),
+   // and DrawBallHistory then re-creates them from scratch (CreateInstance + AddPart +
+   // RenderSetup) — full GPU resource churn per part. That's ~150 ms/frame with 25 trail lines
+   // in a Debug build. The DrawLine/DrawIntersectionCircle fast-path can only kick in if the
+   // parts SURVIVE between frames, so we only clear when the user actually does something
+   // (navigation, enter, toggle) — not on the every-frame "no input, just running" call.
+   if (menuAction != MenuOptionsRecord::MenuActionType::MenuActionType_None)
+   {
+      ClearDraws(player);
+   }
 
    if (!m_MenuOptions.m_MenuError.empty())
    {

--- a/src/core/ballhistory.h
+++ b/src/core/ballhistory.h
@@ -899,6 +899,33 @@ private:
    std::map<std::string, CComObject<Light>*> m_DrawnIntersectionCircles;
    std::map<std::string, CComObject<Rubber>*> m_DrawnLines;
 
+   // Per-frame geometry caches — when a DrawLine/DrawIntersectionCircle call comes in with
+   // the same parameters as last frame, we skip the expensive RenderRelease+RenderSetup that
+   // tears down + rebuilds GPU buffers. Without this, every cached line/circle thrashes its
+   // mesh buffer at end-of-frame, which alone consumes ~280-440ms/frame in normal-mode trail
+   // draw with ~25 line segments. With this, a stationary trail pays zero per-frame cost.
+   struct DrawnLineGeom
+   {
+      Vertex3Ds m_PosA;
+      Vertex3Ds m_PosB;
+      DWORD m_Color;
+      int m_Thickness;
+   };
+   struct DrawnCircleGeom
+   {
+      Vertex3Ds m_Position;
+      float m_IntersectionRadiusPercent;
+      DWORD m_Color;
+   };
+   std::map<std::string, DrawnLineGeom> m_DrawnLinesGeomCache;
+   std::map<std::string, DrawnCircleGeom> m_DrawnIntersectionCirclesGeomCache;
+
+   // Hash of the inputs to DrawBallHistory's last successful run. If the next call has the
+   // same inputs and the previous frame's drawn parts are still alive in m_DrawnLines/
+   // m_DrawnBalls, we skip the entire 3-pass walk over the ring buffer — those parts are
+   // still attached to the table and will re-render unchanged. Reset to 0 on ClearDraws.
+   uint64_t m_LastDrawBallHistoryInputsHash;
+
    DWORD m_AutoControlBallColor;
    DWORD m_RecallBallColor;
    DWORD m_TrainerBallStartColor;


### PR DESCRIPTION
## Problem

Opening the Ball History menu in normal mode dropped FPS from ~110 to **1-2 fps** in Debug_BGFX. Live cdb diagnosis showed `BallHistory::DrawBallHistory` consuming 280-441 ms/frame.

## Root cause

`ProcessMenu` was calling `ClearDraws` every single frame (even when there was no menu input), tearing down all cached `Rubber` line / `Light` / `Ball` GPU resources and re-creating them from scratch — full `RenderRelease` + `RenderSetup` (re-tessellation + VB/IB realloc + GPU upload) per part per frame. Plus `DrawBallHistory` was walking the 1500-8000 entry ring buffer three times per call regardless of whether anything had changed.

## Fix (three layered changes)

1. **Don't `ClearDraws` every frame in `ProcessMenu`** — only on actual menu actions (UpLeft/DownRight/Enter/Toggle). Trail parts persist between frames.
2. **Cache last-frame inputs in `DrawLine` / `DrawIntersectionCircle`** — skip the entire mutate + `RenderRelease` + `RenderSetup` path if posA/posB/color/thickness (or position/radius/color for circles) match the last call.
3. **Hash inputs in `DrawBallHistory` and early-out if unchanged** — skip the 3-pass walk over `m_BallHistoryRecords` when the visual is identical to last frame.

## Measured

`m_DrawBallHistoryUsec`: 280-441 ms → effectively 0 in steady state. Total `BallHistory::Process` cost: ~280 ms → < 1 ms. FPS in the menu trail screen: 1-2 → 60+.

Diagnosed live via cdb non-invasive snapshots of the running cabinet process (Black Pyramid table). All three fixes verified end-to-end on the cabinet.

## Files

- `src/core/ballhistory.h` — adds geom-cache map types and last-inputs-hash field
- `src/core/ballhistory.cpp` — gates ClearDraws, adds fast-path/early-out, clears caches on teardown