### PR TITLE
Skill + docs iteration: status-vpx redesign, gitignore additions, cabinet-rotation docs

### DIFF
--- a/.claude/skills/status-vpx/SKILL.md
+++ b/.claude/skills/status-vpx/SKILL.md
@@ -1,28 +1,96 @@
 ---
 name: status-vpx
-description: Print a structured status of Gary's vpinball_ballhistory repo — branch positions (master vs upstream, integration vs master, development vs integration), the extra patches master carries on top of upstream, working-tree state, open PRs on garybrowndev/vpinball, and a one-line reminder of his fork-development workflow. Use this whenever Gary asks "what's the state of my branches", "what's going on in my repo", "where am I", "where's master / integration / development", "what fixes do I have on top of upstream", "what PRs do I have open", "give me a status", "/status-vpx", or any variant where he wants the current shape of his vpinball fork at a glance. Read-only — runs `git fetch --prune` against origin and upstream and prints; never modifies branches or pushes.
+description: Print a compact status of Gary's vpinball_ballhistory fork. Centerpiece is four flow rows showing what each branch is missing from its neighbor — `upstream → master`, `master → integration`, `integration → development`, and the flipped `integration ← development` (the PR-back direction). Each non-zero row gets a 2-line LLM-synthesized digest. Plus master local-patches side note, compact origin sync block, working-tree changes, CI status, and any open PRs. Use this whenever Gary asks "where am I", "what's the state of my fork", "show me my branches", "what's going on in my repo", "what's not pushed", "what should I pull", "did the last build pass", "what's CI doing", "give me a status", or runs `/status-vpx`. Read-only — fetches origin and upstream non-destructively.
 ---
 
-# status-vpx — vpinball_ballhistory repo status reporter
+# status-vpx — fork status reporter
 
-Gary works in this repo across three long-lived branches with a specific topology:
+Gary maintains a 3-branch fork on top of upstream:
 
 ```
-upstream/master   ──► master   ──► integration   ──► development
-   (vpinball)      (+B2S patch)   (+ Ball History)    (+ WIP)
+upstream/master ─► master (+B2S patch) ─► integration (+Ball History) ─► development (+WIP)
 ```
 
-When he asks "what's the state of things" he wants a quick read of:
+This skill produces a single status report. Section order:
 
-1. Where each branch is relative to the next layer up/down
-2. What patches `master` carries on top of `upstream/master` (today: the B2S compat stub `3ea227d80`)
-3. Ball History commits riding on `integration` over `master`
-4. WIP commits on `development` over `integration`
-5. Working tree dirty? Open PRs?
+1. **Header** — repo name, current HEAD branch, timestamp
+2. **`## CI status`** — latest commit per canonical branch with PASS/FAIL rollup (omitted when no runs)
+3. **`## Branch stack`** — four flow rows + master local-patches side note + compact origin sync block
+4. **`## Working tree`** — `git status` as a table (omitted when clean)
+5. **`## Open PRs`** — only when there are open PRs
 
-This skill runs the bundled status script and presents the output to Gary unmodified — it's a status reporter, not an interpreter. If something looks off (e.g. master has unexpected extra patches, or integration is way behind master), call it out briefly *after* the report.
+## The Branch stack section
 
-## Run the script
+Four flow rows. The first three read parent → child (top of stack down). The last is **flipped** — `integration ← development` — so integration stays anchored on the left across the rows that involve it. No leading bullet/marker — the arrow inside the row carries the direction.
+
+Raw script output (what the script emits before Claude polishes it):
+
+```
+upstream → master               29 commit(s) to bring in (upstream has stuff master hasn't pulled in yet)   [range: master..upstream/master]
+master → integration            no new commits
+integration → development       no new commits
+integration ← development       11 commit(s) to bring in (development has WIP integration hasn't pulled back via PR)   [range: integration..development]
+```
+
+Each non-zero row carries a **parenthesized plain-English hint** explaining what the count means in that direction (e.g. "upstream has stuff master hasn't pulled in yet"). These hints are hardcoded in the script orchestration — don't change them at presentation time.
+
+After the fenced code block, a **single-line side note** for the local patches `master` carries on top of `upstream`, then a **3-column `Origin sync` table** (`Branch` | `Origin status (garybrowndev/vpinball)` | `What to do`) where the `What to do` column gives plain-English next-step guidance ("pull 2 from origin", "push 1 to origin", "nothing to do"). All emitted by the script verbatim — no Claude polish needed.
+
+### Synthesizing the 2 rich summary lines (Claude's job, every run)
+
+The script does **not** emit commit subjects. For each row that says `N commit(s) to bring in`, Claude must:
+
+1. Run `git log <range> --format='%s' -n 30` using the `[range: ...]` shown on that row.
+2. Read the subjects, group them by theme (rendering fixes, build infra, perf, new feature stack, etc.), and write **2 concise rich summary lines** describing the substance of those commits.
+3. Insert those 2 lines as indented bullets directly under the row inside the fenced code block.
+4. **Strip the `[range: ...]` suffix from the row** in the polished output — it's a hint for Claude, not for Gary. Keep the parenthesized hint (e.g. "(upstream has stuff master hasn't pulled in yet)") — it's part of what Gary sees.
+
+Polished output:
+
+```
+upstream → master               29 commit(s) to bring in (upstream has stuff master hasn't pulled in yet)
+       BGFX render-loop overhaul — per-frame VSync, tonemapper exposure, latency/stability fixes
+       UI & build hygiene — InGameUI display-size handling, joystick naming, dmdutil/dof bumps
+master → integration            no new commits
+integration → development       no new commits
+integration ← development       11 commit(s) to bring in (development has WIP integration hasn't pulled back via PR)
+       Trainer polish — result-hold Time freeze, status panel layout, async pass/fail sounds
+       Rendering & infra — runtime Material for DrawLine, corridor XY rotation, perf cuts
+```
+
+Rules for the summary lines:
+- **Two lines, no more.** If there are 50 commits, distill them into 2 themed buckets.
+- **Each line max 120 characters.** Hard cap. If you can't fit it, tighten the wording — don't wrap, don't truncate mid-word, don't drop the cap. Why: keeps the fenced block from soft-wrapping in narrow terminals and keeps the digest scannable at a glance.
+- **No raw subjects, no truncation marks, no `_(+N more)_` tags.** This is a digest, not a sample.
+- **Concrete and specific.** "Bug fixes and improvements" is useless — name the subsystems and the kinds of changes.
+- **Skip noise.** Merge commits, version bumps, whitespace cleanups — fold into the theme or drop.
+- **Don't touch the master local-patches side note.** It comes from `get_stack_bullets()` as a single line emitted by the script — leave it verbatim.
+
+### Working-tree "What changed" column (Claude's job, every run)
+
+The Working tree table emits 3 columns: `Status | File | What changed`, where the third column is a `_[describe]_` placeholder. For each row, Claude must replace the placeholder with **one short sentence** describing what changed in that file.
+
+How to do this efficiently:
+- Untracked files (`??`): just describe what the file is for based on path/extension (e.g. ".jks signing keystore for Android release builds"). Don't read the file.
+- Modified files: run `git diff <file>` (or `git diff --cached <file>` for staged) and write a 1-sentence summary of the actual diff. Keep it concrete — name the function, section, or behavior touched.
+- For tiny edits (renamed var, comment fix), say so: "Renamed X → Y" / "Updated comment near Z".
+- For bigger edits, summarize the most substantive change in one phrase. Don't list everything — pick the headline.
+
+The column should make Gary glance at his working tree and instantly remember what he was doing in each file without opening it.
+
+### Arrow rules (one each, no exceptions)
+
+- **Stack flows use `→` for downward (parent→child), `←` only on the last row** so `integration` stays the left column. Arrow points from source toward target.
+- **Origin sync uses `▲ unpushed` / `▼ unpulled` / `✓ in sync`.** Push goes up to origin, pull comes down — both real.
+
+### What fills each line
+
+- **Flow row count** — `git rev-list --count <target>..<source>`.
+- **Flow row summary (2 lines)** — synthesized by Claude from `git log <range>` at presentation time. See above.
+- **Side-note bullets** — hardcoded labels from `get_stack_bullets()` for the `master/upstream` key. Edit those when the master patch set shifts.
+- **Origin sync** — short one-liner from `origin_state()` per branch.
+
+## Run it
 
 ```bash
 bash .claude/skills/status-vpx/scripts/status.sh
@@ -30,27 +98,20 @@ bash .claude/skills/status-vpx/scripts/status.sh
 
 The script:
 
-- `git fetch --prune` against `origin` and `upstream` so the report isn't stale (non-destructive)
-- Prints sections in this order: header → working-tree → remotes → key-branch ahead/behind → patches master carries on upstream → patches integration carries on master → patches development carries on integration → other local branches → open PRs (via `gh`) → workflow reminder
+- runs `git fetch --quiet --prune` against `origin` and `upstream` (non-destructive)
+- needs `gh` CLI for the CI and PR sections (skipped gracefully if missing) and `python3` for JSON parsing
+- omits any section that has nothing to report
 
-If the script fails (e.g. `upstream` remote not configured on this clone), surface the error to Gary rather than silently working around it — his repos always have both remotes.
+## How to present the output
 
-## After running
+The script emits markdown directly. **Paste it into your reply unfenced** — don't wrap the whole thing in a ``` fence or the tables become raw `|` text. The Branch stack rows are *internally* fenced by the script (so column alignment renders correctly in monospace); leave that fence alone.
 
-1. Pipe the script output verbatim to Gary as a fenced block
-2. If anything jumps out as anomalous, add 1-3 lines after the block flagging it. Examples:
-   - `master` has more than 1 patch on top of `upstream/master` and the extras don't look like the B2S stub → ask what they are
-   - `integration` is *behind* `master` → he probably hasn't done the post-upstream-sync merge yet
-   - `development` has many commits behind `integration` → maybe stale
-   - Working tree is dirty with files that look like accidental edits (e.g. `.build/` artifacts, `third-party/` overwrites)
-3. Don't propose actions unless he asks. He uses this command to *see* state, not to be told what to do.
-
-## Why the script and not inline git commands
-
-The git ahead/behind math is fiddly (have to verify each remote-tracking ref exists before counting, handle the missing-upstream case, format the `gh pr list` JSON). A bundled script is faster, deterministic, and the same script can be wired into a status-line or polled by a separate agent later if Gary wants.
+Synthesize the 2-line digests per the rules above, then emit the rest verbatim.
 
 ## Editing tips
 
-- The "Workflow reminder" tail block at the end of the script is a memory aid for new Claude sessions that have just started in this repo. Keep it terse.
-- The patches-on-master section is the most important diagnostic — if Gary ever ends up with surprise commits there it's a sign of a botched upstream rebase. Don't trim it.
-- `gh pr list --repo garybrowndev/vpinball` is hardcoded; if the fork ever moves, update both places.
+- **Master local-patch labels** live in `get_stack_bullets()` near the top of the script (the `master/upstream` case — 2 lines). Edit when the master patch set shifts.
+- **Flow-row column width** is the `w=32` default in `emit_flow`; bump if branch names get longer.
+- **CI section** lists only the canonical 3 branches (+ current HEAD if non-canonical). Old feature branches won't appear.
+- All `gh` invocations go through the `$GH` resolver at the top of the script, which tries `gh`, `gh.exe`, and a couple of WinGet paths so this works from WSL bash.
+- If the fork ever moves off `garybrowndev/vpinball`, both `gh pr list` and `gh run list` reference it.

--- a/.claude/skills/status-vpx/SKILL.md
+++ b/.claude/skills/status-vpx/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: status-vpx
+description: Print a structured status of Gary's vpinball_ballhistory repo — branch positions (master vs upstream, integration vs master, development vs integration), the extra patches master carries on top of upstream, working-tree state, open PRs on garybrowndev/vpinball, and a one-line reminder of his fork-development workflow. Use this whenever Gary asks "what's the state of my branches", "what's going on in my repo", "where am I", "where's master / integration / development", "what fixes do I have on top of upstream", "what PRs do I have open", "give me a status", "/status-vpx", or any variant where he wants the current shape of his vpinball fork at a glance. Read-only — runs `git fetch --prune` against origin and upstream and prints; never modifies branches or pushes.
+---
+
+# status-vpx — vpinball_ballhistory repo status reporter
+
+Gary works in this repo across three long-lived branches with a specific topology:
+
+```
+upstream/master   ──► master   ──► integration   ──► development
+   (vpinball)      (+B2S patch)   (+ Ball History)    (+ WIP)
+```
+
+When he asks "what's the state of things" he wants a quick read of:
+
+1. Where each branch is relative to the next layer up/down
+2. What patches `master` carries on top of `upstream/master` (today: the B2S compat stub `3ea227d80`)
+3. Ball History commits riding on `integration` over `master`
+4. WIP commits on `development` over `integration`
+5. Working tree dirty? Open PRs?
+
+This skill runs the bundled status script and presents the output to Gary unmodified — it's a status reporter, not an interpreter. If something looks off (e.g. master has unexpected extra patches, or integration is way behind master), call it out briefly *after* the report.
+
+## Run the script
+
+```bash
+bash .claude/skills/status-vpx/scripts/status.sh
+```
+
+The script:
+
+- `git fetch --prune` against `origin` and `upstream` so the report isn't stale (non-destructive)
+- Prints sections in this order: header → working-tree → remotes → key-branch ahead/behind → patches master carries on upstream → patches integration carries on master → patches development carries on integration → other local branches → open PRs (via `gh`) → workflow reminder
+
+If the script fails (e.g. `upstream` remote not configured on this clone), surface the error to Gary rather than silently working around it — his repos always have both remotes.
+
+## After running
+
+1. Pipe the script output verbatim to Gary as a fenced block
+2. If anything jumps out as anomalous, add 1-3 lines after the block flagging it. Examples:
+   - `master` has more than 1 patch on top of `upstream/master` and the extras don't look like the B2S stub → ask what they are
+   - `integration` is *behind* `master` → he probably hasn't done the post-upstream-sync merge yet
+   - `development` has many commits behind `integration` → maybe stale
+   - Working tree is dirty with files that look like accidental edits (e.g. `.build/` artifacts, `third-party/` overwrites)
+3. Don't propose actions unless he asks. He uses this command to *see* state, not to be told what to do.
+
+## Why the script and not inline git commands
+
+The git ahead/behind math is fiddly (have to verify each remote-tracking ref exists before counting, handle the missing-upstream case, format the `gh pr list` JSON). A bundled script is faster, deterministic, and the same script can be wired into a status-line or polled by a separate agent later if Gary wants.
+
+## Editing tips
+
+- The "Workflow reminder" tail block at the end of the script is a memory aid for new Claude sessions that have just started in this repo. Keep it terse.
+- The patches-on-master section is the most important diagnostic — if Gary ever ends up with surprise commits there it's a sign of a botched upstream rebase. Don't trim it.
+- `gh pr list --repo garybrowndev/vpinball` is hardcoded; if the fork ever moves, update both places.

--- a/.claude/skills/status-vpx/scripts/status.sh
+++ b/.claude/skills/status-vpx/scripts/status.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# status-vpx — print a structured status of the vpinball_ballhistory repo.
+# Read-only. Runs from anywhere inside the repo.
+
+set -u
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "ERROR: not inside a git repo" >&2
+  exit 1
+}
+
+# Always have an up-to-date view of remotes — but never fetch destructively.
+# Prune stale remote-tracking refs so the report doesn't lie.
+git fetch --quiet --prune origin 2>/dev/null || true
+git fetch --quiet --prune upstream 2>/dev/null || true
+
+hr() { printf -- '----------------------------------------\n'; }
+
+# ---- header ----
+echo "Repo:    $(git rev-parse --show-toplevel)"
+echo "Date:    $(date '+%Y-%m-%d %H:%M:%S')"
+echo "Branch:  $(git rev-parse --abbrev-ref HEAD)"
+hr
+
+# ---- working-tree state ----
+echo "## Working tree"
+if [ -z "$(git status --porcelain)" ]; then
+  echo "  clean"
+else
+  git status --short | sed 's/^/  /'
+fi
+hr
+
+# ---- remotes ----
+echo "## Remotes"
+git remote -v | awk '!seen[$1$3]++ {printf "  %-10s %s (%s)\n", $1, $2, $3}'
+hr
+
+# ---- key branches: ahead/behind tracking ----
+echo "## Key branches"
+printf "  %-14s %-44s %s\n" "BRANCH" "TIP" "AHEAD/BEHIND vs upstream/origin"
+
+for br in master integration development; do
+  if ! git show-ref --verify --quiet "refs/heads/$br"; then
+    printf "  %-14s %s\n" "$br" "(missing locally)"
+    continue
+  fi
+  tip=$(git log -1 --format='%h %s' "$br" 2>/dev/null | cut -c1-42)
+
+  vs_upstream=""
+  if git show-ref --verify --quiet "refs/remotes/upstream/master"; then
+    a=$(git rev-list --count "upstream/master..$br" 2>/dev/null || echo "?")
+    b=$(git rev-list --count "$br..upstream/master" 2>/dev/null || echo "?")
+    vs_upstream="upstream/master: +$a / -$b"
+  fi
+
+  vs_origin=""
+  if git show-ref --verify --quiet "refs/remotes/origin/$br"; then
+    a=$(git rev-list --count "origin/$br..$br" 2>/dev/null || echo "?")
+    b=$(git rev-list --count "$br..origin/$br" 2>/dev/null || echo "?")
+    vs_origin="origin/$br: +$a / -$b"
+  fi
+
+  printf "  %-14s %-44s %s | %s\n" "$br" "$tip" "$vs_upstream" "$vs_origin"
+done
+hr
+
+# ---- master patch list (commits master carries on top of upstream) ----
+echo "## Patches master carries on top of upstream/master"
+if git show-ref --verify --quiet "refs/remotes/upstream/master" \
+   && git show-ref --verify --quiet "refs/heads/master"; then
+  count=$(git rev-list --count upstream/master..master 2>/dev/null || echo 0)
+  if [ "$count" = "0" ]; then
+    echo "  (none — master is at upstream/master)"
+  else
+    git log --format='  %h %s' upstream/master..master
+  fi
+else
+  echo "  (cannot compute — upstream/master or master missing)"
+fi
+hr
+
+# ---- ball history patches: integration on top of master ----
+echo "## Patches integration carries on top of master"
+if git show-ref --verify --quiet "refs/heads/master" \
+   && git show-ref --verify --quiet "refs/heads/integration"; then
+  count=$(git rev-list --count master..integration 2>/dev/null || echo 0)
+  if [ "$count" = "0" ]; then
+    echo "  (none — integration is at master)"
+  else
+    echo "  ($count commits — showing first 15)"
+    git log --format='  %h %s' master..integration | head -15
+  fi
+fi
+hr
+
+# ---- development on top of integration ----
+echo "## Patches development carries on top of integration"
+if git show-ref --verify --quiet "refs/heads/integration" \
+   && git show-ref --verify --quiet "refs/heads/development"; then
+  count=$(git rev-list --count integration..development 2>/dev/null || echo 0)
+  if [ "$count" = "0" ]; then
+    echo "  (none — development is at integration)"
+  else
+    echo "  ($count commits — showing first 15)"
+    git log --format='  %h %s' integration..development | head -15
+  fi
+fi
+hr
+
+# ---- other local branches (everything not in the canonical 3) ----
+echo "## Other local branches"
+others=$(git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | grep -vE '^(master|integration|development)$' || true)
+if [ -z "$others" ]; then
+  echo "  (none)"
+else
+  for br in $others; do
+    tip=$(git log -1 --format='%h %s' "$br" 2>/dev/null | cut -c1-60)
+    printf "  %-32s %s\n" "$br" "$tip"
+  done
+fi
+hr
+
+# ---- open PRs (gh) ----
+# WSL bash doesn't always see Windows PATH; try gh, gh.exe, and known winget link.
+echo "## Open PRs"
+GH=""
+for cand in gh gh.exe "/c/Users/$USER/AppData/Local/Microsoft/WinGet/Links/gh.exe" "/mnt/c/Users/gary.brown/AppData/Local/Microsoft/WinGet/Links/gh.exe"; do
+  if command -v "$cand" >/dev/null 2>&1 || [ -x "$cand" ]; then
+    GH="$cand"
+    break
+  fi
+done
+
+if [ -n "$GH" ]; then
+  prs_origin=$("$GH" pr list --repo garybrowndev/vpinball --state open --json number,title,headRefName,baseRefName 2>/dev/null || echo "")
+  if [ -z "$prs_origin" ] || [ "$prs_origin" = "[]" ]; then
+    echo "  origin (garybrowndev/vpinball): none"
+  else
+    echo "  origin (garybrowndev/vpinball):"
+    echo "$prs_origin" | python -c 'import json,sys
+for p in json.load(sys.stdin):
+    print(f"    #{p[\"number\"]} {p[\"title\"]}  ({p[\"headRefName\"]} -> {p[\"baseRefName\"]})")'
+  fi
+else
+  echo "  (gh CLI not on PATH in this shell — skipping)"
+fi
+hr
+
+echo "## Workflow reminder"
+echo "  upstream sync : fetch upstream, rebase master onto upstream/master, force-push origin master"
+echo "                  (master carries B2S compat patch — ff-only WILL fail; rebase is expected)"
+echo "  ship to integ : merge master into integration, rebuild, test"
+echo "  ship to dev   : merge integration into development"
+echo "  ship feature  : PR development -> integration on GitHub"
+echo "  branch state  : master = upstream + B2S patch ; integration = master + Ball History ; development = integration + WIP"

--- a/.claude/skills/status-vpx/scripts/status.sh
+++ b/.claude/skills/status-vpx/scripts/status.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# status-vpx — print a structured status of the vpinball_ballhistory repo.
-# Read-only. Runs from anywhere inside the repo.
+# status-vpx — minimal repo status. Centerpiece is the "Branch stack"
+# section: a single ASCII visualization (in a fenced code block) walking
+# upstream → master → integration → development with edge-diff bullets and
+# origin sync state on each node. Other sections (working tree, CI, PRs)
+# are omitted when empty. Output is markdown. The caller MUST paste this
+# output unfenced — the Branch stack diagram has its own internal fence.
 
 set -u
 
@@ -9,149 +13,323 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" || {
   exit 1
 }
 
-# Always have an up-to-date view of remotes — but never fetch destructively.
-# Prune stale remote-tracking refs so the report doesn't lie.
 git fetch --quiet --prune origin 2>/dev/null || true
 git fetch --quiet --prune upstream 2>/dev/null || true
 
-hr() { printf -- '----------------------------------------\n'; }
+GH=""
+for c in gh gh.exe \
+         "/c/Users/$USER/AppData/Local/Microsoft/WinGet/Links/gh.exe" \
+         "/mnt/c/Users/gary.brown/AppData/Local/Microsoft/WinGet/Links/gh.exe"; do
+  if command -v "$c" >/dev/null 2>&1 || [ -x "$c" ]; then GH="$c"; break; fi
+done
+
+cur_branch=$(git rev-parse --abbrev-ref HEAD)
+
+origin_state() {
+  local br="$1"
+  git show-ref --verify --quiet "refs/remotes/origin/$br" || { echo "no origin"; return; }
+  local a b
+  a=$(git rev-list --count "origin/$br..$br" 2>/dev/null || echo 0)
+  b=$(git rev-list --count "$br..origin/$br" 2>/dev/null || echo 0)
+  if [ "$a" = "0" ] && [ "$b" = "0" ]; then echo "in sync ✓"; return; fi
+  local s=""
+  # ▲ = local has commits origin doesn't (push direction)
+  # ▼ = origin has commits local doesn't (pull direction)
+  [ "$a" -gt 0 ] && s="$s ▲ $a unpushed"
+  [ "$b" -gt 0 ] && s="$s ▼ $b unpulled"
+  echo "${s# }"
+}
+
+# Plain-English action line for an origin/<branch> state. Same args as origin_state.
+origin_action() {
+  local br="$1"
+  git show-ref --verify --quiet "refs/remotes/origin/$br" || { echo "—"; return; }
+  local a b
+  a=$(git rev-list --count "origin/$br..$br" 2>/dev/null || echo 0)
+  b=$(git rev-list --count "$br..origin/$br" 2>/dev/null || echo 0)
+  if [ "$a" = "0" ] && [ "$b" = "0" ]; then echo "nothing to do"; return; fi
+  local pull="" push=""
+  [ "$b" -gt 0 ] && pull="pull $b from origin"
+  [ "$a" -gt 0 ] && push="push $a to origin"
+  if [ -n "$pull" ] && [ -n "$push" ]; then echo "$pull, then $push"
+  else echo "${pull}${push}"
+  fi
+}
 
 # ---- header ----
-echo "Repo:    $(git rev-parse --show-toplevel)"
-echo "Date:    $(date '+%Y-%m-%d %H:%M:%S')"
-echo "Branch:  $(git rev-parse --abbrev-ref HEAD)"
-hr
+echo "**vpinball_ballhistory** · HEAD: \`$cur_branch\` · $(date '+%Y-%m-%d %H:%M')"
+echo ""
 
-# ---- working-tree state ----
-echo "## Working tree"
-if [ -z "$(git status --porcelain)" ]; then
-  echo "  clean"
-else
-  git status --short | sed 's/^/  /'
+# ---- branch stack ----
+# One unified visualization: the patch stack from upstream root down to HEAD.
+# Each edge between branches lists what differs (with up to 2 commit subjects);
+# each branch node shows its sync state with origin and any unpushed/unpulled
+# commit subjects below it.
+
+ahead_count() { git rev-list --count "$1..$2" 2>/dev/null || echo 0; }
+
+# Hardcoded 2-bullet semantic labels for stack-layer ahead portions.
+# Args: stack-pair-key. Echoes 2 lines (one per bullet).
+get_stack_bullets() {
+  case "$1" in
+    "master/upstream")
+      echo "B2S compat stub for PinUp-Popper backglass discovery"
+      echo "2 local fixes — .NET COM hang, InputManager device-ID collision"
+      ;;
+    "integration/master")
+      echo "Ball History feature stack — physics replay + trainer mode"
+      echo "Build/debug/skill tooling and bundled assets"
+      ;;
+    "development/integration")
+      echo "Active WIP — small fixes and experiments"
+      echo "Awaiting verification before merging into integration"
+      ;;
+  esac
+}
+
+# Compute all branch comparison counts up-front.
+have_um=0; um_a=0; um_b=0
+if git show-ref --verify --quiet refs/remotes/upstream/master \
+   && git show-ref --verify --quiet refs/heads/master; then
+  have_um=1
+  um_a=$(ahead_count upstream/master master)
+  um_b=$(ahead_count master upstream/master)
 fi
-hr
 
-# ---- remotes ----
-echo "## Remotes"
-git remote -v | awk '!seen[$1$3]++ {printf "  %-10s %s (%s)\n", $1, $2, $3}'
-hr
-
-# ---- key branches: ahead/behind tracking ----
-echo "## Key branches"
-printf "  %-14s %-44s %s\n" "BRANCH" "TIP" "AHEAD/BEHIND vs upstream/origin"
-
-for br in master integration development; do
-  if ! git show-ref --verify --quiet "refs/heads/$br"; then
-    printf "  %-14s %s\n" "$br" "(missing locally)"
-    continue
-  fi
-  tip=$(git log -1 --format='%h %s' "$br" 2>/dev/null | cut -c1-42)
-
-  vs_upstream=""
-  if git show-ref --verify --quiet "refs/remotes/upstream/master"; then
-    a=$(git rev-list --count "upstream/master..$br" 2>/dev/null || echo "?")
-    b=$(git rev-list --count "$br..upstream/master" 2>/dev/null || echo "?")
-    vs_upstream="upstream/master: +$a / -$b"
-  fi
-
-  vs_origin=""
-  if git show-ref --verify --quiet "refs/remotes/origin/$br"; then
-    a=$(git rev-list --count "origin/$br..$br" 2>/dev/null || echo "?")
-    b=$(git rev-list --count "$br..origin/$br" 2>/dev/null || echo "?")
-    vs_origin="origin/$br: +$a / -$b"
-  fi
-
-  printf "  %-14s %-44s %s | %s\n" "$br" "$tip" "$vs_upstream" "$vs_origin"
-done
-hr
-
-# ---- master patch list (commits master carries on top of upstream) ----
-echo "## Patches master carries on top of upstream/master"
-if git show-ref --verify --quiet "refs/remotes/upstream/master" \
-   && git show-ref --verify --quiet "refs/heads/master"; then
-  count=$(git rev-list --count upstream/master..master 2>/dev/null || echo 0)
-  if [ "$count" = "0" ]; then
-    echo "  (none — master is at upstream/master)"
-  else
-    git log --format='  %h %s' upstream/master..master
-  fi
-else
-  echo "  (cannot compute — upstream/master or master missing)"
+have_om=0; om_a=0; om_b=0
+if git show-ref --verify --quiet refs/heads/master \
+   && git show-ref --verify --quiet refs/remotes/origin/master; then
+  have_om=1
+  om_a=$(ahead_count origin/master master)
+  om_b=$(ahead_count master origin/master)
 fi
-hr
 
-# ---- ball history patches: integration on top of master ----
-echo "## Patches integration carries on top of master"
-if git show-ref --verify --quiet "refs/heads/master" \
-   && git show-ref --verify --quiet "refs/heads/integration"; then
-  count=$(git rev-list --count master..integration 2>/dev/null || echo 0)
-  if [ "$count" = "0" ]; then
-    echo "  (none — integration is at master)"
-  else
-    echo "  ($count commits — showing first 15)"
-    git log --format='  %h %s' master..integration | head -15
-  fi
+have_mi=0; mi_a=0; mi_b=0
+if git show-ref --verify --quiet refs/heads/master \
+   && git show-ref --verify --quiet refs/heads/integration; then
+  have_mi=1
+  mi_a=$(ahead_count master integration)
+  mi_b=$(ahead_count integration master)
 fi
-hr
 
-# ---- development on top of integration ----
-echo "## Patches development carries on top of integration"
-if git show-ref --verify --quiet "refs/heads/integration" \
-   && git show-ref --verify --quiet "refs/heads/development"; then
-  count=$(git rev-list --count integration..development 2>/dev/null || echo 0)
-  if [ "$count" = "0" ]; then
-    echo "  (none — development is at integration)"
-  else
-    echo "  ($count commits — showing first 15)"
-    git log --format='  %h %s' integration..development | head -15
-  fi
+have_oi=0; oi_a=0; oi_b=0
+if git show-ref --verify --quiet refs/heads/integration \
+   && git show-ref --verify --quiet refs/remotes/origin/integration; then
+  have_oi=1
+  oi_a=$(ahead_count origin/integration integration)
+  oi_b=$(ahead_count integration origin/integration)
 fi
-hr
 
-# ---- other local branches (everything not in the canonical 3) ----
-echo "## Other local branches"
-others=$(git for-each-ref --format='%(refname:short)' refs/heads/ \
-  | grep -vE '^(master|integration|development)$' || true)
-if [ -z "$others" ]; then
-  echo "  (none)"
-else
-  for br in $others; do
-    tip=$(git log -1 --format='%h %s' "$br" 2>/dev/null | cut -c1-60)
-    printf "  %-32s %s\n" "$br" "$tip"
+have_id=0; id_a=0; id_b=0
+if git show-ref --verify --quiet refs/heads/integration \
+   && git show-ref --verify --quiet refs/heads/development; then
+  have_id=1
+  id_a=$(ahead_count integration development)
+  id_b=$(ahead_count development integration)
+fi
+
+have_od=0; od_a=0; od_b=0
+if git show-ref --verify --quiet refs/heads/development \
+   && git show-ref --verify --quiet refs/remotes/origin/development; then
+  have_od=1
+  od_a=$(ahead_count origin/development development)
+  od_b=$(ahead_count development origin/development)
+fi
+
+# Helper: read up-to-2 bullet lines from a function/range invocation into b1/b2.
+read_two() {
+  # Reads stdin into globals __b1 / __b2
+  __b1=""; __b2=""
+  local line i=0
+  while IFS= read -r line; do
+    i=$((i+1))
+    if [ $i = 1 ]; then __b1="$line"
+    elif [ $i = 2 ]; then __b2="$line"
+    fi
   done
-fi
-hr
+}
 
-# ---- open PRs (gh) ----
-# WSL bash doesn't always see Windows PATH; try gh, gh.exe, and known winget link.
-echo "## Open PRs"
-GH=""
-for cand in gh gh.exe "/c/Users/$USER/AppData/Local/Microsoft/WinGet/Links/gh.exe" "/mnt/c/Users/gary.brown/AppData/Local/Microsoft/WinGet/Links/gh.exe"; do
-  if command -v "$cand" >/dev/null 2>&1 || [ -x "$cand" ]; then
-    GH="$cand"
-    break
+# Print one flow row: "<left> <arrow> <right>   N commits to bring in (hint)",
+# or "no new commits" when count is 0. The parenthesized hint explains in plain
+# English what the count means for that direction (e.g. "upstream has stuff
+# master hasn't pulled in yet"). The `[range: ...]` suffix is a hint for Claude
+# to git log against when synthesizing the 2-line digest at presentation time.
+# Args: left_label, arrow, right_label, count, range, hint, label_width
+emit_flow() {
+  local left="$1" arrow="$2" right="$3" n="$4" range="$5" hint="$6" w="${7:-32}"
+  local pair
+  pair=$(printf "%s %s %s" "$left" "$arrow" "$right")
+  if [ "$n" = "0" ]; then
+    printf "%-${w}s  no new commits\n" "$pair"
+    return
   fi
-done
+  printf "%-${w}s  %s commit(s) to bring in (%s)   [range: %s]\n" "$pair" "$n" "$hint" "$range"
+}
 
+emit_ci_status() {
+  [ -z "$GH" ] && return
+  local runs
+  runs=$("$GH" run list --repo garybrowndev/vpinball --limit 60 \
+    --json status,conclusion,headBranch,headSha,name,displayTitle,createdAt 2>/dev/null || echo "")
+  [ -z "$runs" ] || [ "$runs" = "[]" ] && return
+  local branches_filter="master,integration,development"
+  case "$cur_branch" in
+    master|integration|development) ;;
+    *) branches_filter="$branches_filter,$cur_branch" ;;
+  esac
+  echo "## CI status"
+  echo ""
+  echo "$runs" | BRANCHES="$branches_filter" python3 -c '
+import json, sys, os, datetime as dt
+from collections import defaultdict
+
+allowed = set(os.environ.get("BRANCHES","").split(","))
+
+def rel(ts):
+    if not ts: return ""
+    try: then = dt.datetime.fromisoformat(ts.replace("Z","+00:00"))
+    except Exception: return ts
+    diff = (dt.datetime.now(dt.timezone.utc) - then).total_seconds()
+    if diff < 60:    return f"{int(diff)}s ago"
+    if diff < 3600:  return f"{int(diff/60)}m ago"
+    if diff < 86400: return f"{int(diff/3600)}h ago"
+    return f"{int(diff/86400)}d ago"
+
+runs = json.load(sys.stdin)
+branch_latest = {}
+for r in runs:
+    br = r.get("headBranch") or ""
+    if br not in allowed: continue
+    ts = r.get("createdAt") or ""
+    sha = (r.get("headSha") or "")[:7]
+    cur = branch_latest.get(br)
+    if cur is None or ts > cur[0]:
+        branch_latest[br] = (ts, sha, r.get("displayTitle") or "")
+
+groups = defaultdict(list)
+for r in runs:
+    br = r.get("headBranch") or ""
+    sha = (r.get("headSha") or "")[:7]
+    if br in branch_latest and sha == branch_latest[br][1]:
+        groups[br].append(r)
+
+order = ["master","integration","development"]
+for b in branch_latest:
+    if b not in order: order.append(b)
+
+if not groups:
+    print("_no recent runs on tracked branches_")
+else:
+    print("| Branch | Result | Commit | Title | When |")
+    print("|---|---|---|---|---|")
+    for br in order:
+        if br not in groups: continue
+        rs = groups[br]
+        total  = len(rs)
+        pass_n = sum(1 for r in rs if r.get("conclusion") == "success")
+        fail_n = sum(1 for r in rs if r.get("conclusion") == "failure")
+        pend_n = sum(1 for r in rs if r.get("status") in ("in_progress","queued"))
+        if fail_n:            result = f"**{fail_n}/{total} FAIL**"
+        elif pend_n:          result = f"{pend_n}/{total} RUN"
+        elif pass_n == total: result = f"{total}/{total} ✓"
+        else:                 result = f"{pass_n}/{total} ?"
+        ts, sha, title = branch_latest[br]
+        title = (title or "")[:50]
+        print(f"| {br} | {result} | `{sha}` | {title} | {rel(ts)} |")
+'
+  echo ""
+}
+
+# Section order: CI status → Branch stack (rows + side note + origin sync) → Working tree → Open PRs.
+emit_ci_status
+
+echo "## Branch stack"
+echo ""
+echo "_Rows show \`source → target\` (last row flipped to keep integration anchored left). HEAD: \`$cur_branch\`._"
+echo ""
+echo '```'
+
+# The 4 flows. Arrow points from source toward target. First three rows
+# read left-to-right (parent → child); the last is flipped (integration ← development)
+# so the integration column lines up vertically across rows where it matters.
+# Each non-zero row gets a parenthesized plain-English hint explaining the count.
+[ $have_um = 1 ] && emit_flow "upstream"    "→" "master"      "$um_b" "master..upstream/master"      "upstream has stuff master hasn't pulled in yet"
+[ $have_mi = 1 ] && emit_flow "master"      "→" "integration" "$mi_b" "integration..master"          "master has stuff integration hasn't merged in yet"
+[ $have_id = 1 ] && emit_flow "integration" "→" "development" "$id_b" "development..integration"     "integration has stuff development hasn't merged in yet"
+[ $have_id = 1 ] && emit_flow "integration" "←" "development" "$id_a" "integration..development"     "development has WIP integration hasn't pulled back via PR"
+
+echo '```'
+echo ""
+
+# Side note: master's local patches on top of upstream — single line.
+if [ $have_um = 1 ] && [ "$um_a" != "0" ]; then
+  read_two < <(get_stack_bullets "master/upstream")
+  echo "_Side note — master carries **$um_a** local patch(es) on top of upstream so things build: ${__b1}; ${__b2}._"
+  echo ""
+fi
+
+# Origin sync state as a table — caption folded into the "Status" header.
+echo "| Branch | Origin status (\`garybrowndev/vpinball\`) | What to do |"
+echo "|---|---|---|"
+[ $have_om = 1 ] && echo "| \`master\` | $(origin_state master) | $(origin_action master) |"
+[ $have_oi = 1 ] && echo "| \`integration\` | $(origin_state integration) | $(origin_action integration) |"
+[ $have_od = 1 ] && echo "| \`development\` | $(origin_state development) | $(origin_action development) |"
+echo ""
+
+case "$cur_branch" in
+  master|integration|development) ;;
+  *) echo "_HEAD is on \`$cur_branch\` — off the canonical 3 branches._"; echo "" ;;
+esac
+
+# ---- working tree ----
+dirty=$(git status --porcelain | wc -l | tr -d ' ')
+if [ "$dirty" != "0" ]; then
+  echo "## Working tree — $dirty change(s)"
+  echo ""
+  echo "| Status | File | What changed |"
+  echo "|---|---|---|"
+  git status --porcelain | while IFS= read -r line; do
+    st=$(echo "${line:0:2}" | sed 's/ /·/g')
+    f="${line:3}"
+    echo "| \`$st\` | $f | _[describe]_ |"
+  done
+  echo ""
+fi
+
+# ---- open PRs ----
 if [ -n "$GH" ]; then
-  prs_origin=$("$GH" pr list --repo garybrowndev/vpinball --state open --json number,title,headRefName,baseRefName 2>/dev/null || echo "")
-  if [ -z "$prs_origin" ] || [ "$prs_origin" = "[]" ]; then
-    echo "  origin (garybrowndev/vpinball): none"
-  else
-    echo "  origin (garybrowndev/vpinball):"
-    echo "$prs_origin" | python -c 'import json,sys
+  prs=$("$GH" pr list --repo garybrowndev/vpinball --state open \
+    --json number,title,headRefName,baseRefName,isDraft,statusCheckRollup 2>/dev/null || echo "")
+  if [ -n "$prs" ] && [ "$prs" != "[]" ]; then
+    echo "## Open PRs"
+    echo ""
+    echo "| # | Title | Branch → Base | Draft | Checks |"
+    echo "|---|---|---|---|---|"
+    echo "$prs" | python3 -c '
+import json, sys
+def roll(checks):
+    if not checks: return "—"
+    p=f=pe=0
+    for c in checks:
+        s=(c.get("conclusion") or c.get("state") or "").upper()
+        if s=="SUCCESS": p+=1
+        elif s in ("FAILURE","ERROR","TIMED_OUT"): f+=1
+        else: pe+=1
+    parts=[]
+    if p:  parts.append(f"✓{p}")
+    if f:  parts.append(f"✗{f}")
+    if pe: parts.append(f"…{pe}")
+    return " ".join(parts) or "—"
 for p in json.load(sys.stdin):
-    print(f"    #{p[\"number\"]} {p[\"title\"]}  ({p[\"headRefName\"]} -> {p[\"baseRefName\"]})")'
+    num   = p["number"]
+    title = (p.get("title") or "")[:50]
+    head  = p.get("headRefName") or ""
+    base  = p.get("baseRefName") or ""
+    draft = "yes" if p.get("isDraft") else "no"
+    chk   = roll(p.get("statusCheckRollup"))
+    print(f"| #{num} | {title} | `{head}` → `{base}` | {draft} | {chk} |")
+'
+    echo ""
   fi
-else
-  echo "  (gh CLI not on PATH in this shell — skipping)"
 fi
-hr
 
-echo "## Workflow reminder"
-echo "  upstream sync : fetch upstream, rebase master onto upstream/master, force-push origin master"
-echo "                  (master carries B2S compat patch — ff-only WILL fail; rebase is expected)"
-echo "  ship to integ : merge master into integration, rebuild, test"
-echo "  ship to dev   : merge integration into development"
-echo "  ship feature  : PR development -> integration on GitHub"
-echo "  branch state  : master = upstream + B2S patch ; integration = master + Ball History ; development = integration + WIP"

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,16 @@ refcount_trace.log
 crash.txt
 crash.dmp
 
+# build logs left in repo root by helper scripts
+/build_*.log
+
+# Android signing keystores — secrets, never check in
+*.jks
+*.keystore
+
+# Claude Code local state (scheduled tasks lockfile, etc.)
+.claude/*.lock
+
 # local research notes (not for upstream)
 _research/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,32 @@ When upstream changes conflict with Ball History integration points:
 - **In-game settings UI**: Press F12 while playing (replaces old Video Options dialog)
 - **Ball History debug log**: `<exe folder>/BallHistory/ballhistory_debug.log` (Debug builds only)
 
+### Cabinet table-rotation universal fix (`ViewCabRotation = 90.000000`)
+
+In Gary's `VPinballX.ini` `[TableOverride]` section, `ViewCabRotation = 90.000000` is the universal cabinet-orientation fix. Empirically verified across a 500-table audit — produces the correct landscape orientation for **both** of the rotation regimes that exist in the wild:
+
+- **Legacy-mode tables** (~98% of tables, ROTF=270 baked in `.vpx`)
+- **Window-mode tables with the broken-author bug** (ROTF=0 baked, e.g. White Water v.1.2, 4 Queens, World Poker Tour, Space Station VPW, Junior, Defender VPW, Central Park)
+
+**Why one value fixes both modes** (`src/renderer/ViewSetup.cpp`):
+- Window mode (`GetRotation`, line 302-306) auto-adds `270°` for landscape viewports before applying the user value: setting 90 → effective `(270 + 90) % 360 = 0°` (no rotation, table fills landscape directly because Window mode already maps physical screen cm to playfield).
+- Legacy mode (line 309-310, plus `MatrixScale(mSceneScaleX, -mSceneScaleY, -mSceneScaleZ)` Y/Z-axis flip in `ComputeMVP` line 447) applies the user value through a flipped coordinate system, so 90° in legacy is not the geometric inverse of 270° in window — the combined transforms produce equivalent visual orientations on a landscape display.
+
+**Practical implication**: when triaging a table that renders "wrong orientation" on the cabinet, **first** assume the global override already covers it. Per-table sidecar `.ini` files (`<table>.ini` next to `<table>.vpx` with `[TableOverride] ViewCabRotation = X`) are only needed for genuine outliers — not the routine ROTF=0 author bug.
+
+**Limitation**: only verified on Gary's landscape cabinet (4K landscape physical, BGSet=1, ScreenWidth=95.9 / Height=53.9 cm). Different cabinet geometries (portrait monitor, head-tracking, VR) may need different values.
+
+**Diagnosing future "wrong orientation" reports**: extract `GameStg/GameData` stream from the `.vpx` (it's an OLE compound document — 7-Zip lists/extracts streams directly) and binary-grep for the 4-byte tags. The full set is in `src/parts/pintable.cpp:1225-1227`, but the ones to check first are:
+
+| Tag (Cabinet view setup) | Meaning | Type |
+|---|---|---|
+| `VSM1` | Cabinet view layout mode (0=LEGACY, 1=CAMERA, 2=WINDOW) | int32 |
+| `ROTF` | Cabinet viewport rotation in degrees | float |
+| `SCFX/SCFY/SCFZ` | Cabinet scene scale | float |
+| `XLFX/XLFY/XLFZ` | Cabinet camera position | float |
+| `LAYF` | Cabinet layback | float |
+| `FOVF` | Cabinet field of view | float |
+
 ## Architecture
 
 ### Source Layout (`src/`)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,234 @@
 # Ball History for Visual Pinball
-Fork of Visual Pinball for development of Ball History feature.
-Ball History allows for historical ball control and training sessions for the purpose of improving pinball skill.
-Only tested on Windows x64 with DirectX 3D graphics engine.
 
-To build (and merge):
-- Sync code
-- Extract VPinballX-<VERSION>-<BUILD>-<HASH>-dev-third-party-windows-x64-Debug to .\third-party and overwrite all files
-- Extract VPinballX-<VERSION>-<BUILD>-<HASH>-dev-third-party-windows-x64-Release to .\third-party and overwrite all files
-- Revert all changes from above overwrite of files
-- (If merging) Merge changes from branch
-- Run .\make\create_vs_solution.bat
-- Select 2022
-- Open .\.build\vsproject\VisualPinball.sln in Visual Studio 2022
-- Set "vpx" as the Startup Project
-- Build VPinball Debug / x64
-- Build VPinball Release / x64
+A fork of [Visual Pinball](https://github.com/vpinball/vpinball) (VPinballX) that adds the **Ball History** feature — a system for recording, replaying, and training with ball state during gameplay. Useful for analysing what happened on a given shot, recreating tricky situations, and drilling specific shots over and over to improve pinball skill.
 
-To try out
-- Hit "V" button while playing
-- Read menus/descriptions and figure it out
-- DM  [@garybrowndev](https://www.github.com/garybrowndev) if you have feedback or issues
+The fork is maintained at [`garybrowndev/vpinball`](https://github.com/garybrowndev/vpinball). All three **Windows x64** rendering backends — DirectX, OpenGL, and BGFX — are regularly built and tested in both Debug and Release for Ball History development. Non-Windows platforms compile (the feature is `#ifdef`-guarded out) but are not actively exercised.
+
+> Looking for the upstream Visual Pinball README? [Jump to the original ↓](#visual-pinball)
+
+> **AI-assisted development.** This fork is built with heavy use of AI tooling — primarily [Claude Code](https://www.claude.com/product/claude-code) — for everything from Ball History feature work to upstream-merge conflict resolution, debugging, and documentation (including this README). Contributors are **encouraged** to use Claude Code (or equivalent) during active development. The repo ships with a detailed [`CLAUDE.md`](CLAUDE.md) (build recipes, upstream-API change tracking, debugging lessons, trainer phase timeline) that is consumed by Claude Code automatically as project context — keep it up to date when you change conventions, and it pays for itself on the next session.
+
+## What Ball History does
+
+Ball History runs as an in-game overlay on top of any VPX table. While playing, press **`V`** to open the Ball History menu. The feature has two operational modes:
+
+### Normal mode — record / replay / recall
+- Continuously snapshots every ball's full physics state (position, velocity, angular momentum, orientation) into timestamped `BallHistoryRecord`s.
+- Press **`R`** during play to recall a previous ball state — useful for rewinding to "right before that drain" without restarting the table.
+- Take manual control of one or more balls: pause the simulation, scrub through history, drag balls to new positions on the playfield, and resume play from the new state.
+- Auto-control vertices: place waypoints on the playfield and have the system steer a ball through them — handy for exercising specific shot lines repeatably.
+
+### Trainer mode — drill specific shots
+- Define a **start location** (where the ball spawns, with optional X/Y/Z offset and initial velocity), a **pass corridor** (geometry the ball must travel through to count as a pass), and a **fail zone** (region that ends the run as a fail).
+- Configure runs per session, countdown delay between runs, ball-hold during countdown, physics variance per run (so you're not drilling against a deterministic target), gameplay difficulty (separate from variance), and a per-run timeout.
+- The trainer plays a result sound (pass / fail / timeout) and holds the result on screen for a configurable result-display window before starting the next countdown.
+- Per-run results are tracked and shown in a status panel (Previous / Current / Remaining) with overall pass/fail tallies for the session.
+- Trainer configurations are saved per-table as `.ini` files and reload automatically when you re-open the same table.
+
+### How it's drawn
+- The menu, status panel, and per-run text are rendered via ImGui overlay in `LiveUI`.
+- Physical visualisations on the playfield (fake balls, the corridor walls, the fail-zone intersection circle, vertex labels) reuse VPinball's own parts system — `CComObject<Ball>`, `CComObject<Light>`, `CComObject<Rubber>` — so they shade and rotate correctly with whatever camera/cabinet view the table is using.
+
+## Quick start (try it out)
+
+1. Grab the latest build from `garybrowndev/vpinball` (or build it yourself — see below).
+2. Launch any VPX table and press **`F5`** to start play.
+3. Press **`V`** to open the Ball History menu.
+4. Read the menus / descriptions and figure it out — Normal mode is at the top, Trainer mode is in its own submenu.
+5. Press **`R`** during play to recall the most-recent history snapshot. (Other keys — flippers, plunger, etc. — pass through to ImGui as normal while the menu is open.)
+
+DM [@garybrowndev](https://www.github.com/garybrowndev) with feedback or issues.
+
+## Build (Windows / Visual Studio 2022)
+
+### Quick build (no CMake)
+
+1. Sync the code (`git pull`, etc.).
+2. Download precompiled third-party deps from [upstream GitHub Actions](https://github.com/vpinball/vpinball/actions) — find a successful `vpinball` workflow run on master, download both:
+   - `VPinballX-<VERSION>-dev-third-party-windows-x64-Debug.zip`
+   - `VPinballX-<VERSION>-dev-third-party-windows-x64-Release.zip`
+3. Extract Debug first, then Release, both into `./third-party/`, overwriting existing files.
+4. Revert any git changes caused by the overwrite: `git checkout -- third-party/`.
+5. Run `make/create_vs_solution.bat`, choose `2022`. (Re-run this any time you switch between `master` and `integration`/`development`, or after merging upstream — different `vpx-core.vcxitems` templates are used per branch.)
+6. Open `.build/vsproject/VisualPinball.sln` in Visual Studio 2022.
+7. Set **`vpx`** as the Startup Project.
+8. Build for Debug or Release / x64.
+
+### Third-party deps via GitHub CLI
+
+```bash
+gh run download <RUN_ID> --repo vpinball/vpinball -n "VPinballX-...-dev-third-party-windows-x64-Debug.zip"   --dir /tmp/vpx-deps
+gh run download <RUN_ID> --repo vpinball/vpinball -n "VPinballX-...-dev-third-party-windows-x64-Release.zip" --dir /tmp/vpx-deps-release
+cp -rf /tmp/vpx-deps/*         third-party/
+cp -rf /tmp/vpx-deps-release/* third-party/
+git checkout -- third-party/
+```
+
+### Build tips
+
+- After upstream merges, **always** re-run `make/create_vs_solution.bat`.
+- When changing widely-included headers (`def.h`, `stdafx.h`, `ballhistory.h`), force a full rebuild by deleting all `.obj` files: `rm -rf .build/obj/vpx/Debug-x64/*.obj`. To force a relink, also delete the exe.
+- Build only `vpx` (skip plugin projects): add `-p:BuildProjectReferences=false` to MSBuild.
+- MSBuild from CLI:
+  ```bash
+  "/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" \
+    ".build/vsproject/vpx.vcxproj" -p:Configuration=Debug -p:Platform=x64 -m
+  ```
+
+### CMake build (windows-x64)
+
+```bash
+platforms/windows-x64/external.sh
+cp make/CMakeLists_bgfx-windows-x64.txt CMakeLists.txt
+cmake -G "Visual Studio 17 2022" -A x64 -B build
+cmake --build build --config Release
+```
+
+### Run from CLI with a table preloaded
+
+```bash
+start .build/bin/vpx/Debug-x64/VPinballX64.exe "C:\path\to\Example.vpx"
+```
+
+Press **F5** to play, **ESC** for editor, **Q** to quit play mode. Always launch with a table loaded when iterating on Ball History — starting empty wastes time navigating menus.
+
+### Tests
+
+Build and run the **`vpx-test`** project from the VS solution (`.build/vsproject/vpx-test.vcxproj`). Test sources are in `tests/`.
+
+## Branch strategy
+
+- **`master`** — tracks upstream `vpinball/vpinball` **plus one cherry-picked patch** (the B2S compat stub — see below).
+- **`integration`** — `master` merged with Ball History changes. Build / test branch.
+- **`development`** — active Ball History work. PRs land here first, then ship to `integration` after local verification.
+- **Remotes**: `origin` = `garybrowndev/vpinball`, `upstream` = `vpinball/vpinball`.
+
+### Master is not pure upstream — carries one patch
+
+`origin/master` intentionally carries the **B2S compat stub** (`Restore B2SBackglassServer discovery under modern -Play path`) cherry-picked on top of upstream. This is the one patch required for any stock (non-Ball-History) build to work with PinUp-Popper + B2SBackglassServer on a cabinet — upstream rejected the fix ([PR #2529](https://github.com/vpinball/vpinball/pull/2529)) but the cabinet still needs to boot tables.
+
+Consequence: `git merge --ff-only upstream/master` will fail on master after a fetch. Instead:
+
+```bash
+# Rebase (preferred — clean single-patch history)
+git fetch upstream
+git checkout master
+git rebase upstream/master
+git push --force-with-lease origin master
+```
+
+If the patch ever lands upstream or is replaced, drop the cherry-pick and restore `git merge --ff-only`.
+
+### Sync workflow (upstream → development)
+
+1. `git fetch upstream`
+2. Checkout `master`, **rebase** onto `upstream/master`, force-push to origin.
+3. Checkout `integration`, merge `master` — resolve upstream-vs-Ball-History conflicts here.
+4. Download fresh third-party deps if upstream added new plugins or libraries.
+5. Re-run `make/create_vs_solution.bat`.
+6. Build and test integration.
+7. Merge `integration` into `development`.
+
+When upstream changes conflict with Ball History integration points, the convention is: accept upstream for all conflicts in the merge commit, then re-apply Ball History changes in separate (reviewable) commits. Files that always need re-integration: `player.h/cpp`, `LiveUI.cpp`, `InputManager.cpp`, build files.
+
+## Configuration
+
+- **VPinball settings**: `C:\Users\<user>\AppData\Roaming\VPinballX\10.8\VPinballX.ini`
+- **Ball History settings**: `<exe folder>/BallHistory/` (per-table `.ini` files)
+- **In-game settings UI**: press **F12** while playing (replaces the old Video Options dialog)
+- **Ball History debug log**: `<exe folder>/BallHistory/logs/ballhistory_debug.log` (Debug builds only)
+
+### Cabinet table-rotation universal fix
+
+In a cabinet `VPinballX.ini` `[TableOverride]` section, `ViewCabRotation = 90.000000` is the universal cabinet-orientation fix on a landscape cabinet. Empirically verified across a 500-table audit — produces correct landscape orientation for both rotation regimes seen in the wild (legacy-mode tables with ROTF=270 baked in, and window-mode tables with the ROTF=0 author bug). Works because window mode auto-adds 270° before applying the user value, and legacy mode applies it through a Y/Z-flipped coordinate system; both paths converge on the same visual orientation.
+
+Per-table sidecar `.ini` files (`<table>.ini` next to `<table>.vpx`) are only needed for genuine outliers, not the routine ROTF=0 author bug.
+
+## Source layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/core/` | Application core — main entry, player loop, settings, pin table, undo, **Ball History** |
+| `src/physics/` | Physics engine, collision, quad trees, ball/flipper/plunger hit objects |
+| `src/renderer/` | Rendering abstraction (DirectX / OpenGL / bgfx), shaders, render targets, VR |
+| `src/parts/` | Pinball table elements (Ball, Bumper, Flipper, Gate, Kicker, Light, Ramp, Rubber, Spinner, Surface, Trigger, …) |
+| `src/ui/` | Editor UI, debugger, live UI, dialog properties |
+| `src/input/` | InputManager (SDL-based, replaces old PinInput / DirectInput) |
+| `src/audio/` | Audio playback (miniaudio, replaces old SDL_mixer) |
+| `src/math/`, `src/utils/`, `src/assets/`, `src/shaders/`, `src/plugins/` | Math, utilities, bundled assets, shaders, plugin host |
+| `make/` | VS solution / project templates, CMake files per platform, build scripts |
+| `platforms/` | Per-platform external dependency build scripts |
+| `plugins/` | Runtime plugin implementations (PinMAME, DMD, DOF, B2S, …) |
+| `standalone/` | Standalone builds (iOS, Android, macOS — not Ball History targets) |
+| `third-party/` | Precompiled external dependencies (gitignored — must be downloaded) |
+
+### Ball History feature (`src/core/ballhistory.h` / `.cpp`)
+
+The primary area of active development (~10,800 lines combined). Key types:
+
+- **`BallHistory`** — central controller integrated into the `Player` game loop. Owns `NormalOptions` and `TrainerOptions`.
+- **`BallHistoryState`** — snapshot of one ball's physics state.
+- **`BallHistoryRecord`** — timestamped collection of `BallHistoryState` for all tracked balls.
+- **`BHLog`** — Debug-build logger; writes to `<exe>/BallHistory/logs/ballhistory_debug.log` via `BHLOG(fmt, ...)`. Release builds get a no-op stub.
+- **`EnumAssignKeys`** — defined in `ballhistory.h` (was previously in `pininput.h`, which upstream removed). Ball History is the sole consumer.
+- **Platform guard** — the full implementation is wrapped in `#ifdef __BALLHISTORY_WIN32__`; non-Windows platforms get a no-op stub so cross-platform builds still link.
+
+### Key integration points
+
+- **`Player`** (`src/core/player.h`) — owns the `BallHistory` instance; constructor inits, destructor uninits, `ApplyPlayingState` resets trainer timing.
+- **`LiveUI`** (`src/ui/live/LiveUI.cpp`) — calls `BallHistory::Process` / `ProcessKeys` / `ProcessMouse` each frame during `RenderUI`.
+- **`InputManager`** (`src/input/InputManager.cpp`) — registers `V` (menu) and `R` (recall) actions that dispatch to `BallHistory::ProcessKeys`.
+- **`HitBall`** (`src/physics/hitball.h`) — has `friend struct BallHistory` for `m_oldpos` access.
+- **`PinTable`** (`src/parts/pintable.h`) — provides part management (`AddPart` / `RemovePart`) and element access via `GetParts()`.
+
+### Rendering object lifecycle (Ball History → VPX parts)
+
+Creating a visual (fake ball, line, intersection circle):
+
+1. `CComObject<T>::CreateInstance(&obj); obj->AddRef();`
+2. `obj->Init(...);`
+3. `obj->m_wzName = L"uniqueName";` (required by `AddPart`)
+4. `m_ptable->AddPart(obj);` (sets `m_ptable`, calls `AddRef`)
+5. `obj->RenderSetup(renderDevice);` (must be after `AddPart`)
+
+Destroying:
+
+1. `obj->RenderRelease();` (must be before `RemovePart`)
+2. `m_ptable->RemovePart(obj);` (calls `Release`)
+3. Clear from the tracking map.
+
+After `UnInit`, call `m_renderer->m_renderDevice->SubmitRenderFrame()` to flush pending GPU resources.
+
+## Debugging
+
+- **Crash handler** produces resolved x64 stack traces in `crash.txt` (the upstream stack code was patched to use `IMAGE_FILE_MACHINE_AMD64` and a rewritten `WriteCallStack`). Always check `crash.txt` first.
+- **`BHLog`** writes to `<exe>/BallHistory/logs/ballhistory_debug.log` in Debug builds. Each `BHLOG(...)` call auto-flushes. Canonical log filenames are `static constexpr` members on `BHLog` — add new ones there rather than hardcoding paths.
+- **Visual Studio attach** — useful when `crash.txt` is missing (the SEH crash handler doesn't catch `_purecall`, `abort()`, or CRT assertion dialogs). From Git Bash:
+  ```bash
+  cmd //c start "" "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe" //DebugExe "C:\path\to\VPinballX64.exe"
+  ```
+  The double slash on `//DebugExe` is required — Git Bash MSYS rewrites single-slash args to Unix paths and breaks the launch.
+- **Conditional breakpoints for teardown bugs** — many UAFs only fire in `BallHistory::UnInit`, which is called only from `Player::~Player()`. Breakpoint at `ballhistory.cpp` `UnInit` to fire exclusively during teardown rather than every frame.
+- **Refcount inspection** — watch `m_dwRef` on COM objects; `0xDDDDDDDD` is MSVC Debug CRT's dead-land fill and confirms a delete-then-use bug.
+
+### Known issues
+
+- **RenderDevice pending buffer assertion** — Debug-only assertion on exit after Ball History use (`m_pendingSharedIndexBuffers.empty()`). Mitigated by `SubmitRenderFrame()` in destructor; may still fire in some exit paths.
+- **Trainer key collisions with table scripts** — the menu key was moved from `C` to `V` after `Example.vpx`'s VBScript "Manual Ball Control" was found to bind to `C` (keycode 46) and silently freeze the ball when the menu opened. If a new collision is suspected on another table, signal to look for: a specific ball velocity literal being written every physics step. Grep the table script for that constant first — it's almost certainly the table, not the physics engine.
+
+## Code style
+
+- `.clang-format` is present: WebKit base, Allman braces, 3-space indent, 190-column limit, tabs = 3 spaces.
+- Member variables use `m_` prefix (e.g., `m_Position`, `m_BallHistoryRecords`).
+- Enums use `TypeName_Value` naming (e.g., `ModeStateType_Config`, `MenuStateType_Root_SelectMode`).
+- Static constants defined as `static const` class members.
+- COM objects used for rendered elements (`CComObject<Ball>`, `CComObject<Light>`, `CComObject<Rubber>`).
+
+## Further reading
+
+See [`CLAUDE.md`](CLAUDE.md) for the full developer guide — upstream API change tracking, a trainer-phase timeline reference, and a catalogue of debugging lessons learned the expensive way (one symptom value pointing at a VBScript collision rather than the physics engine, sync-vs-async sound stalls in Win32 `PlaySound`, etc.).
+
+---
 
 Original readme for forked repo below...
 
@@ -57,5 +266,4 @@ Documentation is currently sparse. Check the [docs](docs) directory for various 
 ## How to build
 
 Build instructions are available in the [make directory README](make/README.md).
-
 

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -243,6 +243,7 @@ TrainerOptions::TrainerOptions()
    , m_TotalRuns(5)
    , m_MaxSecondsPerRun(15)
    , m_CountdownSecondsBeforeRun(3)
+   , m_ForceInitialDelayOnControlExit(false)
    , m_BallStartOptionsRecordsSize(0)
    , m_CurrentRunRecord(0)
    , m_RunStartTimeMs(0)
@@ -1225,6 +1226,11 @@ void BallHistory::SetControl(bool control)
       {
          SaveSettings(*g_pplayer);
          g_pplayer->SetPlayState(!g_pplayer->IsPlaying());
+         // Coming out of control (menu closed). When the trainer's configured countdown is 0,
+         // ProcessModeTrainer would otherwise launch the run on the very next frame — too
+         // abrupt right after closing the menu. Mark this transition so the trainer applies a
+         // one-time forced ~1s delay. Cleared when the run transitions from countdown to active.
+         m_MenuOptions.m_TrainerOptions.m_ForceInitialDelayOnControlExit = true;
       }
    }
 }
@@ -8945,7 +8951,15 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
 
    TrainerOptions::RunRecord& currentRunRecord = m_MenuOptions.m_TrainerOptions.m_RunRecords[m_MenuOptions.m_TrainerOptions.m_CurrentRunRecord];
    int32_t runElapsedTimeMs = currentTimeMs - m_MenuOptions.m_TrainerOptions.m_RunStartTimeMs;
-   if (runElapsedTimeMs == 0 || runElapsedTimeMs < (m_MenuOptions.m_TrainerOptions.m_CountdownSecondsBeforeRun * int32_t(OneSecondMs)))
+   // Effective countdown: the user-configured value, with a one-time silent ~1s delay added
+   // when the user just exited the menu and the configured countdown is 0. Run-to-run
+   // transitions (no menu involvement) leave this equal to the user value.
+   const int32_t userCountdownMs = m_MenuOptions.m_TrainerOptions.m_CountdownSecondsBeforeRun * int32_t(OneSecondMs);
+   const int32_t effectiveCountdownMs
+      = (userCountdownMs == 0 && m_MenuOptions.m_TrainerOptions.m_ForceInitialDelayOnControlExit)
+         ? TrainerOptions::ForcedInitialDelayMs
+         : userCountdownMs;
+   if (runElapsedTimeMs == 0 || runElapsedTimeMs < effectiveCountdownMs)
    {
       ShowRemainingRunInfo();
       ShowPreviousRunRecord();
@@ -8989,8 +9003,7 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
 
       player.m_renderer->m_trailForBalls = 0;
    }
-   else if (runElapsedTimeMs
-      < ((m_MenuOptions.m_TrainerOptions.m_CountdownSecondsBeforeRun * int32_t(OneSecondMs)) + (m_MenuOptions.m_TrainerOptions.m_MaxSecondsPerRun * int32_t(OneSecondMs))))
+   else if (runElapsedTimeMs < (effectiveCountdownMs + (m_MenuOptions.m_TrainerOptions.m_MaxSecondsPerRun * int32_t(OneSecondMs))))
    {
       if (m_MenuOptions.m_TrainerOptions.m_CountdownSoundPlayed != -1)
       {
@@ -9039,6 +9052,9 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
          }
 
          m_MenuOptions.m_TrainerOptions.m_SetupBallStarts = false;
+         // The forced-initial-delay was consumed once, when this run transitioned from
+         // countdown to active. Subsequent run-to-run transitions (no menu involvement) skip it.
+         m_MenuOptions.m_TrainerOptions.m_ForceInitialDelayOnControlExit = false;
          if (anyVelocityAngularMomentumSet == false)
          {
             player.m_renderer->m_trailForBalls = m_UseTrailsForBallsInitialValue;

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -181,13 +181,14 @@ const char* TrainerOptions::BallCorridorOptionsRecord::ImGuiDrawTrainerBallCorri
 const char* TrainerOptions::BallCorridorOptionsRecord::ImGuiDrawTrainerBallCorridorOpeningRightLabel = "DrawTrainerBallCorridorOpeningRight";
 
 TrainerOptions::BallCorridorOptionsRecord::BallCorridorOptionsRecord()
-   : BallCorridorOptionsRecord(Vertex3Ds(0.0f, 0.0f, 0.0f), RadiusPercentMaximum, Vertex3Ds(0.0f, 0.0f, 0.0f), Vertex3Ds(0.0f, 0.0f, 0.0f))
+   : BallCorridorOptionsRecord(Vertex3Ds(0.0f, 0.0f, 0.0f), RadiusPercentMaximum, 0.0f, Vertex3Ds(0.0f, 0.0f, 0.0f), Vertex3Ds(0.0f, 0.0f, 0.0f))
 {
 }
 
-TrainerOptions::BallCorridorOptionsRecord::BallCorridorOptionsRecord(const Vertex3Ds& passPosition, float passRadiusPercent, const Vertex3Ds& openingLeft, const Vertex3Ds& openingRight)
+TrainerOptions::BallCorridorOptionsRecord::BallCorridorOptionsRecord(const Vertex3Ds& passPosition, float passRadiusPercent, float passRotationDegrees, const Vertex3Ds& openingLeft, const Vertex3Ds& openingRight)
    : m_PassPosition(passPosition)
    , m_PassRadiusPercent(passRadiusPercent)
+   , m_PassRotationDegrees(passRotationDegrees)
    , m_OpeningPositionLeft(openingLeft)
    , m_OpeningPositionRight(openingRight)
 {
@@ -838,6 +839,7 @@ const char* BallHistory::TrainerModeBallFailRadiusPercentKeyName = "FailRadiusPe
 const char* BallHistory::TrainerModeBallFailAssociationsKeyName = "FailAssociations";
 const char* BallHistory::TrainerModeBallCorridorPassPosition3DKeyName = "BallCorridorPassPosition3D";
 const char* BallHistory::TrainerModeBallCorridorPassRadiusPercentKeyName = "BallCorridorPassRadiusPercent";
+const char* BallHistory::TrainerModeBallCorridorPassRotationDegreesKeyName = "BallCorridorPassRotationDegrees";
 const char* BallHistory::TrainerModeBallCorridorOpeningPositionLeft3DKeyName = "BallCorridorOpeningPositionLeft3D";
 const char* BallHistory::TrainerModeBallCorridorOpeningPositionRight3DKeyName = "BallCorridorOpeningPositionRight3D";
 
@@ -1564,6 +1566,12 @@ void BallHistory::LoadSettings(Player& player)
          && LoadSettingsGetValue(iniFile, TrainerModeSettingsSectionName, TrainerModeBallCorridorOpeningPositionLeft3DKeyName, ballCorridorOpeningPositionLeft3D) == true
          && LoadSettingsGetValue(iniFile, TrainerModeSettingsSectionName, TrainerModeBallCorridorOpeningPositionRight3DKeyName, ballCorridorOpeningPositionRight3D) == true)
       {
+         // PassRotationDegrees was added later; tolerate its absence so configs saved by
+         // older builds load cleanly with rotation defaulting to 0 (= original horizontal
+         // behavior). Loaded outside the && chain so a missing key doesn't fail the rest.
+         std::istringstream ballCorridorPassRotationDegrees;
+         const bool hasPassRotation = LoadSettingsGetValue(iniFile, TrainerModeSettingsSectionName, TrainerModeBallCorridorPassRotationDegreesKeyName, ballCorridorPassRotationDegrees);
+
          while (ballCorridorPassPosition3D.peek() != EOF && ballCorridorPassRadiusPercent.peek() != EOF && ballCorridorOpeningPositionLeft3D.peek() != EOF
             && ballCorridorOpeningPositionRight3D.peek() != EOF)
          {
@@ -1571,6 +1579,11 @@ void BallHistory::LoadSettings(Player& player)
             new (&bcor) TrainerOptions::BallCorridorOptionsRecord();
             ballCorridorPassPosition3D >> bcor.m_PassPosition.x >> delimeter >> bcor.m_PassPosition.y >> delimeter >> bcor.m_PassPosition.z >> delimeter;
             ballCorridorPassRadiusPercent >> bcor.m_PassRadiusPercent >> delimeter;
+            if (hasPassRotation && ballCorridorPassRotationDegrees.peek() != EOF)
+            {
+               ballCorridorPassRotationDegrees >> bcor.m_PassRotationDegrees >> delimeter;
+            }
+            // else m_PassRotationDegrees stays at the constructor default (0.0f)
             ballCorridorOpeningPositionLeft3D >> bcor.m_OpeningPositionLeft.x >> delimeter >> bcor.m_OpeningPositionLeft.y >> delimeter >> bcor.m_OpeningPositionLeft.z >> delimeter;
             ballCorridorOpeningPositionRight3D >> bcor.m_OpeningPositionRight.x >> delimeter >> bcor.m_OpeningPositionRight.y >> delimeter >> bcor.m_OpeningPositionRight.z >> delimeter;
          }
@@ -1814,17 +1827,21 @@ void BallHistory::SaveSettings(Player& player)
 
       std::ostringstream ballBallCorridorPassPosition3D;
       std::ostringstream ballBallCorridorPassRadiusPercent;
+      std::ostringstream ballBallCorridorPassRotationDegrees;
       std::ostringstream ballBallCorridorOpeningPositionLeft3D;
       std::ostringstream ballBallCorridorOpeningPositionRight3D;
       TrainerOptions::BallCorridorOptionsRecord& bcor = m_MenuOptions.m_TrainerOptions.m_BallCorridorOptionsRecord;
       ballBallCorridorPassPosition3D << bcor.m_PassPosition.x << SettingsValueDelimeter << bcor.m_PassPosition.y << SettingsValueDelimeter << bcor.m_PassPosition.z << SettingsValueDelimeter;
       ballBallCorridorPassRadiusPercent << bcor.m_PassRadiusPercent << SettingsValueDelimeter;
+      ballBallCorridorPassRotationDegrees << bcor.m_PassRotationDegrees << SettingsValueDelimeter;
       ballBallCorridorOpeningPositionLeft3D << bcor.m_OpeningPositionLeft.x << SettingsValueDelimeter << bcor.m_OpeningPositionLeft.y << SettingsValueDelimeter << bcor.m_OpeningPositionLeft.z << SettingsValueDelimeter;
       ballBallCorridorOpeningPositionRight3D << bcor.m_OpeningPositionRight.x << SettingsValueDelimeter << bcor.m_OpeningPositionRight.y << SettingsValueDelimeter << bcor.m_OpeningPositionRight.z << SettingsValueDelimeter;
       tempStr = ballBallCorridorPassPosition3D.str();
       iniFile.SetValue(TrainerModeSettingsSectionName, TrainerModeBallCorridorPassPosition3DKeyName, tempStr.c_str());
       tempStr = ballBallCorridorPassRadiusPercent.str();
       iniFile.SetValue(TrainerModeSettingsSectionName, TrainerModeBallCorridorPassRadiusPercentKeyName, tempStr.c_str());
+      tempStr = ballBallCorridorPassRotationDegrees.str();
+      iniFile.SetValue(TrainerModeSettingsSectionName, TrainerModeBallCorridorPassRotationDegreesKeyName, tempStr.c_str());
       tempStr = ballBallCorridorOpeningPositionLeft3D.str();
       iniFile.SetValue(TrainerModeSettingsSectionName, TrainerModeBallCorridorOpeningPositionLeft3DKeyName, tempStr.c_str());
       tempStr = ballBallCorridorOpeningPositionRight3D.str();
@@ -2760,6 +2777,7 @@ bool BallHistory::ShouldDrawTrainerBallCorridor(int currentTimeMs)
       break;
    case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorPassLocation:
    case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorPassWidth:
+   case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorPassRotation:
    case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorOpeningLeftLocation:
    case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorOpeningRightLocation:
       return (currentTimeMs % OneSecondMs) >= ShouldDrawBlinkMs;
@@ -2812,7 +2830,15 @@ void BallHistory::DrawTrainerBallCorridorPass(Player& player, const char* name, 
       float passBallRadius = GetDefaultBallRadius();
       float passWidth = passBallRadius * (bcor.m_PassRadiusPercent / 100.0f);
 
-      DrawLine(player, name, { position->x - passWidth, position->y, position->z }, { position->x + passWidth, position->y, position->z }, m_TrainerBallCorridorPassColor, int(passBallRadius));
+      // Rotate the pass-wall endpoints in the playfield XY plane around the pass position.
+      // 0° = horizontal (along +X), CCW positive. See BallCorridorOptionsRecord::PassRotation*.
+      const float angleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosA = cosf(angleRad);
+      const float sinA = sinf(angleRad);
+      const Vertex3Ds passLeftEnd  = { position->x - passWidth * cosA, position->y - passWidth * sinA, position->z };
+      const Vertex3Ds passRightEnd = { position->x + passWidth * cosA, position->y + passWidth * sinA, position->z };
+
+      DrawLine(player, name, passLeftEnd, passRightEnd, m_TrainerBallCorridorPassColor, int(passBallRadius));
 
       POINT screenPoint = Get2DPointFrom3D(player, *position);
       PrintScreenRecord::Text(name, float(screenPoint.x), float(screenPoint.y), "P");
@@ -2834,7 +2860,12 @@ void BallHistory::DrawTrainerBallCorridorOpeningLeft(Player& player, TrainerOpti
 
    if (!bcor.m_PassPosition.IsZero() && !bcor.m_OpeningPositionLeft.IsZero())
    {
-      DrawLine(player, "BallCorridorOpeningLeftWall", { bcor.m_PassPosition.x - passWidth, bcor.m_PassPosition.y, bcor.m_PassPosition.z }, bcor.m_OpeningPositionLeft, Color::Red,         int(passBallRadius));
+      // Connecting wall starts at the rotated left end of the pass wall, ends at the user-placed opening.
+      const float angleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosA = cosf(angleRad);
+      const float sinA = sinf(angleRad);
+      const Vertex3Ds passLeftEnd = { bcor.m_PassPosition.x - passWidth * cosA, bcor.m_PassPosition.y - passWidth * sinA, bcor.m_PassPosition.z };
+      DrawLine(player, "BallCorridorOpeningLeftWall", passLeftEnd, bcor.m_OpeningPositionLeft, Color::Red, int(passBallRadius));
    }
 }
 
@@ -2853,7 +2884,12 @@ void BallHistory::DrawTrainerBallCorridorOpeningRight(Player& player, TrainerOpt
 
    if (!bcor.m_PassPosition.IsZero() && !bcor.m_OpeningPositionRight.IsZero())
    {
-      DrawLine(player, "BallCorridorOpeningRightWall", { bcor.m_PassPosition.x + passWidth, bcor.m_PassPosition.y, bcor.m_PassPosition.z }, bcor.m_OpeningPositionRight, Color::Red, int(passBallRadius));
+      // Connecting wall starts at the rotated right end of the pass wall, ends at the user-placed opening.
+      const float angleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosA = cosf(angleRad);
+      const float sinA = sinf(angleRad);
+      const Vertex3Ds passRightEnd = { bcor.m_PassPosition.x + passWidth * cosA, bcor.m_PassPosition.y + passWidth * sinA, bcor.m_PassPosition.z };
+      DrawLine(player, "BallCorridorOpeningRightWall", passRightEnd, bcor.m_OpeningPositionRight, Color::Red, int(passBallRadius));
    }
 }
 
@@ -3444,13 +3480,26 @@ void BallHistory::ShowStatus(Player& player, int currentTimeMs)
       statuses.push_back({ "Ball\nCorridor", "" });
       statuses.push_back({ "Pass", std::format("{:.1f}x\n{:.1f}y\n{:.1f}z", bcor.m_PassPosition.x, bcor.m_PassPosition.y, bcor.m_PassPosition.z) });
       statuses.push_back({ "Pass Radius", std::format("{}%", bcor.m_PassRadiusPercent) });
+      statuses.push_back({ "Pass Rotation", std::format("{:.0f}\xC2\xB0", bcor.m_PassRotationDegrees) });
       statuses.push_back({ "Opening\nLeft", std::format("{:.1f}x\n{:.1f}y\n{:.1f}z", bcor.m_OpeningPositionLeft.x, bcor.m_OpeningPositionLeft.y, bcor.m_OpeningPositionLeft.z) });
       statuses.push_back({ "Opening\nRight", std::format("{:.1f}x\n{:.1f}y\n{:.1f}z", bcor.m_OpeningPositionRight.x, bcor.m_OpeningPositionRight.y, bcor.m_OpeningPositionRight.z) });
 
-      Vertex3Ds passPosition1 = bcor.m_PassPosition - Vertex3Ds(GetDefaultBallRadius(), 0.0f, 0.0f);
-      Vertex3Ds passPosition2 = bcor.m_PassPosition + Vertex3Ds(GetDefaultBallRadius(), 0.0f, 0.0f);
+      // Rotate the reference endpoints in the same XY plane the pass wall is rotated in,
+      // so the diagnostic distances match the visible geometry. (Note: this status block
+      // uses GetDefaultBallRadius() instead of passWidth for the offset — pre-existing
+      // discrepancy, not introduced here.)
+      const float statusAngleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float statusCosA = cosf(statusAngleRad);
+      const float statusSinA = sinf(statusAngleRad);
+      const float statusOffset = GetDefaultBallRadius();
+      Vertex3Ds passPosition1 = bcor.m_PassPosition - Vertex3Ds(statusOffset * statusCosA, statusOffset * statusSinA, 0.0f);
+      Vertex3Ds passPosition2 = bcor.m_PassPosition + Vertex3Ds(statusOffset * statusCosA, statusOffset * statusSinA, 0.0f);
       statuses.push_back({ "Distance\nPassL<->PassR", std::format("{:.1f}wu", DistanceToLineSegment(passPosition1, passPosition2, mousePosition3D)) });
-      if (bcor.m_OpeningPositionLeft.x < bcor.m_OpeningPositionRight.x)
+      // Distance-based opening pairing (replaces the original X-coordinate compare which
+      // doesn't survive rotation).
+      const bool statusSwap = DistancePixels(passPosition1, bcor.m_OpeningPositionRight)
+                            < DistancePixels(passPosition1, bcor.m_OpeningPositionLeft);
+      if (!statusSwap)
       {
          statuses.push_back({ "Distance\nPassL<->OpenL", std::format("{:.1f}wu", DistanceToLineSegment(passPosition1, bcor.m_OpeningPositionLeft, mousePosition3D)) });
          statuses.push_back({ "Distance\nPassR<->OpenR", std::format("{:.1f}wu", DistanceToLineSegment(passPosition2, bcor.m_OpeningPositionRight, mousePosition3D)) });
@@ -3880,6 +3929,7 @@ void BallHistory::GetBallCorridorOptionsConfigs(std::vector<std::pair<std::strin
    TrainerOptions::BallCorridorOptionsRecord& bcor = m_MenuOptions.m_TrainerOptions.m_BallCorridorOptionsRecord;
    ballCorridorOptionsConfig.push_back({ "Pass", std::format("{:.2f},{:.2f},{:.2f} (x,y,z)", bcor.m_PassPosition.x, bcor.m_PassPosition.y, bcor.m_PassPosition.z) });
    ballCorridorOptionsConfig.push_back({ "Pass Radius", std::format("{:.0f}%", bcor.m_PassRadiusPercent) });
+   ballCorridorOptionsConfig.push_back({ "Pass Rotation", std::format("{:.0f}\xC2\xB0", bcor.m_PassRotationDegrees) });
    ballCorridorOptionsConfig.push_back({ "Opening Left", std::format("{:.2f},{:.2f},{:.2f} (x,y,z)", bcor.m_OpeningPositionLeft.x, bcor.m_OpeningPositionLeft.y, bcor.m_OpeningPositionLeft.z) });
    ballCorridorOptionsConfig.push_back({ "Opening Right", std::format("{:.2f},{:.2f},{:.2f} (x,y,z)", bcor.m_OpeningPositionRight.x, bcor.m_OpeningPositionRight.y, bcor.m_OpeningPositionRight.z) });
 }
@@ -7305,8 +7355,12 @@ void BallHistory::ProcessMenu(Player& player, MenuOptionsRecord::MenuActionType 
 
       float passBallRadius = GetDefaultBallRadius();
       float passWidth = passBallRadius * (bcor.m_PassRadiusPercent / 100.0f);
-      Vertex3Ds passPositionLeft = { mousePosition3D.x - passWidth, mousePosition3D.y, mousePosition3D.z };
-      Vertex3Ds passPositionRight = { mousePosition3D.x + passWidth, mousePosition3D.y, mousePosition3D.z };
+      // Apply current pass rotation so the live preview lines match what the placed corridor will look like.
+      const float angleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosA = cosf(angleRad);
+      const float sinA = sinf(angleRad);
+      Vertex3Ds passPositionLeft = { mousePosition3D.x - passWidth * cosA, mousePosition3D.y - passWidth * sinA, mousePosition3D.z };
+      Vertex3Ds passPositionRight = { mousePosition3D.x + passWidth * cosA, mousePosition3D.y + passWidth * sinA, mousePosition3D.z };
       DrawLine(player, "BallCorridorPassLocationLeft", passPositionLeft, bcor.m_OpeningPositionLeft, Color::Red, int(passBallRadius));
       DrawLine(player, "BallCorridorPassLocationRight", passPositionRight, bcor.m_OpeningPositionRight, Color::Red, int(passBallRadius));
       DrawTrainerBallCorridorPass(player, "BallCorridorPassLocation", bcor, &mousePosition3D);
@@ -7392,6 +7446,50 @@ void BallHistory::ProcessMenu(Player& player, MenuOptionsRecord::MenuActionType 
          ProcessMenuChangeValueInc<float, float>(bcor.m_PassRadiusPercent, TrainerOptions::BallCorridorOptionsRecord::RadiusPercentMinimum, TrainerOptions::BallCorridorOptionsRecord::RadiusPercentMaximum);
          break;
       case MenuOptionsRecord::MenuActionType::MenuActionType_Enter:
+         m_MenuOptions.m_MenuState = MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorPassRotation;
+         break;
+      default:
+         InvalidEnumValue("MenuOptionsRecord::MenuActionType", menuAction);
+         break;
+      }
+   }
+   break;
+   case MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorPassRotation:
+   {
+      TrainerOptions::BallCorridorOptionsRecord& bcor = m_MenuOptions.m_TrainerOptions.m_BallCorridorOptionsRecord;
+
+      PrintScreenRecord::MenuTitleText("Ball Corridor Pass Rotation (degrees)");
+      PrintScreenRecord::MenuText(false, std::format("(minimum){}\xC2\xB0 <-- {}\xC2\xB0 --> {}\xC2\xB0(maximum)", TrainerOptions::BallCorridorOptionsRecord::PassRotationMinimum, static_cast<int32_t>(bcor.m_PassRotationDegrees), TrainerOptions::BallCorridorOptionsRecord::PassRotationMaximum));
+
+      PrintScreenRecord::MenuText(false, "");
+
+      PrintScreenRecord::MenuTitleText("Current Configuration");
+      std::vector<std::pair<std::string, std::string>> ballCorridorOptionsConfig;
+      GetBallCorridorOptionsConfigs(ballCorridorOptionsConfig);
+      PrintScreenRecord::Results(ballCorridorOptionsConfig);
+
+      ShowSection(DescriptionSectionTitle,
+      {
+         "Use flippers to rotate the pass wall in the playfield XY plane",
+         "0 degrees = pass wall horizontal; 90 = vertical; up to 180",
+         "Hold flipper to skip values quickly"
+      });
+
+      switch (menuAction)
+      {
+      case MenuOptionsRecord::MenuActionType::MenuActionType_None:
+         ProcessMenuChangeValueSkip<float, float>(bcor.m_PassRotationDegrees, TrainerOptions::BallCorridorOptionsRecord::PassRotationMinimum, TrainerOptions::BallCorridorOptionsRecord::PassRotationMaximum, currentTimeMs);
+         break;
+      case MenuOptionsRecord::MenuActionType::MenuActionType_Toggle:
+         // do nothing
+         break;
+      case MenuOptionsRecord::MenuActionType::MenuActionType_UpLeft:
+         ProcessMenuChangeValueDec<float, float>(bcor.m_PassRotationDegrees, TrainerOptions::BallCorridorOptionsRecord::PassRotationMinimum, TrainerOptions::BallCorridorOptionsRecord::PassRotationMaximum);
+         break;
+      case MenuOptionsRecord::MenuActionType::MenuActionType_DownRight:
+         ProcessMenuChangeValueInc<float, float>(bcor.m_PassRotationDegrees, TrainerOptions::BallCorridorOptionsRecord::PassRotationMinimum, TrainerOptions::BallCorridorOptionsRecord::PassRotationMaximum);
+         break;
+      case MenuOptionsRecord::MenuActionType::MenuActionType_Enter:
          m_MenuOptions.m_MenuState = MenuOptionsRecord::MenuStateType::MenuStateType_Trainer_SelectBallCorridorOpeningLeftLocation;
          break;
       default:
@@ -7425,7 +7523,13 @@ void BallHistory::ProcessMenu(Player& player, MenuOptionsRecord::MenuActionType 
 
       float passBallRadius = GetDefaultBallRadius();
       float passWidth = passBallRadius * (bcor.m_PassRadiusPercent / 100.0f);
-      Vertex3Ds passPositionLeft = { bcor.m_PassPosition.x - passWidth, bcor.m_PassPosition.y, bcor.m_PassPosition.z };
+      // Match the rotated pass-wall left endpoint used by DrawTrainerBallCorridorOpeningLeft;
+      // otherwise the placement preview line and the connecting wall start at different
+      // points and cross.
+      const float angleRadL = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosAL = cosf(angleRadL);
+      const float sinAL = sinf(angleRadL);
+      Vertex3Ds passPositionLeft = { bcor.m_PassPosition.x - passWidth * cosAL, bcor.m_PassPosition.y - passWidth * sinAL, bcor.m_PassPosition.z };
       DrawFakeBall(player, "BallCorridorOpeningLeft", mousePosition3D, GetDefaultBallRadius() / 2.0f, m_TrainerBallCorridorOpeningEndColor, &passPositionLeft, Color::Red, int(GetDefaultBallRadius()));
 
 
@@ -7500,7 +7604,11 @@ void BallHistory::ProcessMenu(Player& player, MenuOptionsRecord::MenuActionType 
 
       float passBallRadius = GetDefaultBallRadius();
       float passWidth = passBallRadius * (bcor.m_PassRadiusPercent / 100.0f);
-      Vertex3Ds passPositionRight = { bcor.m_PassPosition.x + passWidth, bcor.m_PassPosition.y, bcor.m_PassPosition.z };
+      // Match the rotated pass-wall right endpoint used by DrawTrainerBallCorridorOpeningRight.
+      const float angleRadR = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+      const float cosAR = cosf(angleRadR);
+      const float sinAR = sinf(angleRadR);
+      Vertex3Ds passPositionRight = { bcor.m_PassPosition.x + passWidth * cosAR, bcor.m_PassPosition.y + passWidth * sinAR, bcor.m_PassPosition.z };
       DrawFakeBall(player, "BallCorridorOpeningRight", mousePosition3D, GetDefaultBallRadius() / 2.0f, m_TrainerBallCorridorOpeningEndColor, &passPositionRight, Color::Red,
          int(GetDefaultBallRadius()));
 
@@ -9334,8 +9442,13 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
       {
          TrainerOptions::BallCorridorOptionsRecord& bcor = m_MenuOptions.m_TrainerOptions.m_BallCorridorOptionsRecord;
          float passWidth = GetDefaultBallRadius() * (bcor.m_PassRadiusPercent / 100.0f);
-         Vertex3Ds passPositionLeft = bcor.m_PassPosition - Vertex3Ds(passWidth, 0.0f, 0.0f);
-         Vertex3Ds passPositionRight = bcor.m_PassPosition + Vertex3Ds(passWidth, 0.0f, 0.0f);
+         // Hit-detection has to use the same rotated endpoints the renderer uses, otherwise
+         // the visual pass wall and the actual collision line drift apart.
+         const float angleRad = bcor.m_PassRotationDegrees * (float)M_PI / 180.0f;
+         const float cosA = cosf(angleRad);
+         const float sinA = sinf(angleRad);
+         Vertex3Ds passPositionLeft = bcor.m_PassPosition - Vertex3Ds(passWidth * cosA, passWidth * sinA, 0.0f);
+         Vertex3Ds passPositionRight = bcor.m_PassPosition + Vertex3Ds(passWidth * cosA, passWidth * sinA, 0.0f);
          {
             std::size_t startToPassCorridorIndex = 0;
             TrainerOptions::RunRecord::ResultType resultType = TrainerOptions::RunRecord::ResultType::ResultType_Unknown;
@@ -9380,7 +9493,12 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
                float distanceToFailLeft = 0.0f;
                float distanceToFailRight = 0.0f;
 
-               if (bcor.m_OpeningPositionLeft.x < bcor.m_OpeningPositionRight.x)
+               // Pair each rotated pass-end with the closer opening point. The original
+               // x-coordinate comparison only worked for horizontal pass walls; with rotation
+               // it can flip the wrong way (e.g., a vertical pass wall would always swap).
+               const bool swap = DistancePixels(passPositionLeft, bcor.m_OpeningPositionRight)
+                              < DistancePixels(passPositionLeft, bcor.m_OpeningPositionLeft);
+               if (!swap)
                {
                   distanceToFailLeft = DistanceToLineSegment(passPositionLeft, bcor.m_OpeningPositionLeft, controlVBall.m_d.m_pos);
                   distanceToFailRight = DistanceToLineSegment(passPositionRight, bcor.m_OpeningPositionRight, controlVBall.m_d.m_pos);

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -19,6 +19,7 @@ bool BallHistory::DrawMenu = false;
 #include "parts/flipper.h"
 #include "parts/light.h"
 #include "parts/rubber.h"
+#include "parts/Material.h"
 #include "renderer/Shader.h"
 #include "meshes/ballMesh.h"
 #include "fonts/DroidSans.h"
@@ -2389,43 +2390,31 @@ void BallHistory::DrawLine(Player& player, const std::string& name, const Vertex
       }
    }
 
-   // Ensure a 1x1 texture exists for this color (reused by name)
-   const std::string imageColorName = "BallHistoryDrawLine" + std::to_string(color);
-   if (player.m_ptable->GetImage(imageColorName) == nullptr)
+   // Get-or-create a single-color Material for this RGB. Reused across every BH line that
+   // draws in the same color (one Material per distinct color per session). This is the
+   // idiomatic way to color a Rubber in VPX — Flipper rubbers (m_szRubberMaterial), Surface
+   // walls (m_szTopMaterial / m_szSideMaterial), Bumpers, Ramps all colorize via Material.
+   // Rubber has no put_Color by design; Shader::SetBasic's no-texture branch
+   // (Shader.cpp:998-1002) routes Material::m_cBase straight to the basic shader's
+   // cBase_Alpha uniform.
+   const std::string materialColorName = "BallHistoryDrawLine" + std::to_string(color);
+   // Note: GetMaterial NEVER returns nullptr for an unknown name — it returns m_dummyMaterial
+   // (which has the user's editor-default color baked in, often pink). Use IsMaterialNameUnique
+   // instead: it returns true exactly when the name is not yet in m_materials.
+   if (player.m_ptable->IsMaterialNameUnique(materialColorName))
    {
-      FIBITMAP* dib = FreeImage_Allocate(1, 1, 24);
-      if (dib)
-      {
-         RGBQUAD singleColor = {};
-         singleColor.rgbBlue = (color >> 16) & 0xFF;
-         singleColor.rgbGreen = (color >> 8) & 0xFF;
-         singleColor.rgbRed = color & 0xFF;
-         FreeImage_SetPixelColor(dib, 0, 0, &singleColor);
-
-         std::string settingsFolderPath;
-         if (GetSettingsFolderPath(settingsFolderPath))
-         {
-            const std::string tmpPath = settingsFolderPath + "\\" + imageColorName + ".png";
-            if (FreeImage_Save(FIF_PNG, dib, tmpPath.c_str(), PNG_DEFAULT))
-            {
-               player.m_ptable->ImportImage(tmpPath, imageColorName);
-               ::DeleteFile(tmpPath.c_str());
-               // ImportImage adds the new texture to m_vimage but only updates the
-               // m_textureMap lookup hash when m_liveBaseTable is set (i.e., when this
-               // table is a live shallow copy). g_pplayer->m_ptable here is the base
-               // table during play (m_liveBaseTable == null, verified via cdb), so the
-               // new texture would never become findable by PinTable::GetImage during
-               // playback — which uses m_textureMap exclusively. Result: every Rubber
-               // line we create renders with a missing texture (the dummy material's
-               // pink fallback). RemoveInvalidReferences rebuilds m_textureMap from
-               // m_vimage, so calling it here makes our newly-imported color findable.
-               // Only fires once per distinct color (the GetImage(name) == nullptr
-               // guard above prevents repeat imports), so the cost is bounded.
-               player.m_ptable->RemoveInvalidReferences();
-            }
-         }
-         FreeImage_Unload(dib);
-      }
+      Material* pMat = new Material();
+      pMat->m_name = materialColorName;
+      pMat->m_cBase = color;
+      pMat->m_fOpacity = 1.0f;
+      pMat->m_bOpacityActive = false;
+      pMat->m_fRoughness = 0.5f;
+      player.m_ptable->AddMaterial(pMat); // takes ownership; pushes to m_materials
+      // m_materialMap is built once at table load from m_materials. New materials added at
+      // runtime are NOT in m_materialMap, so GetMaterial during playback would miss and fall
+      // back to m_dummyMaterial. RemoveInvalidReferences rebuilds m_materialMap from
+      // m_materials, so our newly-added entry becomes findable on the next render frame.
+      player.m_ptable->RemoveInvalidReferences();
    }
 
    // Geometry
@@ -2457,7 +2446,8 @@ void BallHistory::DrawLine(Player& player, const std::string& name, const Vertex
    pLine->m_d.m_height = midpoint.z;
    pLine->m_d.m_thickness = thickness;
    pLine->m_d.m_staticRendering = false;
-   pLine->m_d.m_szImage = imageColorName;
+   pLine->m_d.m_szMaterial = materialColorName; // material drives the color
+   pLine->m_d.m_szImage = "";                   // explicit empty → SetBasic takes no-texture branch
 
    DrawLineRotate(*pLine, midpoint, start, posA);
 

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -2410,6 +2410,18 @@ void BallHistory::DrawLine(Player& player, const std::string& name, const Vertex
             {
                player.m_ptable->ImportImage(tmpPath, imageColorName);
                ::DeleteFile(tmpPath.c_str());
+               // ImportImage adds the new texture to m_vimage but only updates the
+               // m_textureMap lookup hash when m_liveBaseTable is set (i.e., when this
+               // table is a live shallow copy). g_pplayer->m_ptable here is the base
+               // table during play (m_liveBaseTable == null, verified via cdb), so the
+               // new texture would never become findable by PinTable::GetImage during
+               // playback — which uses m_textureMap exclusively. Result: every Rubber
+               // line we create renders with a missing texture (the dummy material's
+               // pink fallback). RemoveInvalidReferences rebuilds m_textureMap from
+               // m_vimage, so calling it here makes our newly-imported color findable.
+               // Only fires once per distinct color (the GetImage(name) == nullptr
+               // guard above prevents repeat imports), so the cost is bounded.
+               player.m_ptable->RemoveInvalidReferences();
             }
          }
          FreeImage_Unload(dib);

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -445,7 +445,10 @@ void BallHistory::PrintScreenRecord::Status(const std::vector<std::pair<std::str
 
 void BallHistory::PrintScreenRecord::ActiveMenu(const std::vector<std::pair<std::string, std::string>>& nameValuePairs)
 {
-   ShowNameValueTable(ImGuiActiveMenuLabel, NormalSmallFont, Color::White, BoldSmallFont, Color::White, 0.80f, 1.00f, nameValuePairs, false, true, nullptr);
+   // positionX=1.00 + center=false → SetWindowPosClamped anchors the window's right edge to the
+   // display edge (clamps to displayWidth - windowWidth). Flush right, matching the FPS overlay
+   // on the bottom-left.
+   ShowNameValueTable(ImGuiActiveMenuLabel, NormalSmallFont, Color::White, BoldSmallFont, Color::White, 1.00f, 1.00f, nameValuePairs, false, false, nullptr);
 }
 
 void BallHistory::PrintScreenRecord::ShowText(const char* name, ImFont* font, const ImU32& fontColor, float positionX, float positionY, bool center, const std::string& message)
@@ -9005,6 +9008,11 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
    }
    else if (runElapsedTimeMs < (effectiveCountdownMs + (m_MenuOptions.m_TrainerOptions.m_MaxSecondsPerRun * int32_t(OneSecondMs))))
    {
+      // Show "Current" panel during the active run so the player can see which run number
+      // they're on and the time remaining. Remaining/Previous stay hidden — they show only
+      // in the countdown and result-hold phases (above and at the top of this function).
+      ShowCurrentRunRecord(currentTimeMs);
+
       if (m_MenuOptions.m_TrainerOptions.m_CountdownSoundPlayed != -1)
       {
          if (m_MenuOptions.m_TrainerOptions.m_SoundEffectsCountdownEnabled)

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -8754,6 +8754,9 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
                m_MenuOptions.m_TrainerOptions.m_TrainerLockedBalls.push_back(ball);
             }
          }
+         ShowRemainingRunInfo();
+         ShowPreviousRunRecord();
+         ShowCurrentRunRecord(currentTimeMs);
          DrawTrainerModeVisuals(player, currentTimeMs);
          return;
       }
@@ -8940,16 +8943,13 @@ void BallHistory::ProcessModeTrainer(Player& player, int currentTimeMs)
       return;
    }
 
-   ShowRemainingRunInfo();
-
-   ShowPreviousRunRecord();
-
-   ShowCurrentRunRecord(currentTimeMs);
-
    TrainerOptions::RunRecord& currentRunRecord = m_MenuOptions.m_TrainerOptions.m_RunRecords[m_MenuOptions.m_TrainerOptions.m_CurrentRunRecord];
    int32_t runElapsedTimeMs = currentTimeMs - m_MenuOptions.m_TrainerOptions.m_RunStartTimeMs;
    if (runElapsedTimeMs == 0 || runElapsedTimeMs < (m_MenuOptions.m_TrainerOptions.m_CountdownSecondsBeforeRun * int32_t(OneSecondMs)))
    {
+      ShowRemainingRunInfo();
+      ShowPreviousRunRecord();
+      ShowCurrentRunRecord(currentTimeMs);
       DrawTrainerModeVisuals(player, currentTimeMs);
       
       for (std::size_t controlVBallIndex = 0; controlVBallIndex < m_ControlVBalls.size(); ++controlVBallIndex)

--- a/src/core/ballhistory.cpp
+++ b/src/core/ballhistory.cpp
@@ -3703,8 +3703,20 @@ void BallHistory::ShowCurrentRunRecord(int currentTimeMs)
    {
       printScreenTexts.push_back({ "Run #", std::format("{} of {}", std::to_string(m_MenuOptions.m_TrainerOptions.m_CurrentRunRecord + 1), m_MenuOptions.m_TrainerOptions.m_RunRecords.size()) });
 
+      // During the result-hold (pass/fail sound playing) the Time field would otherwise keep
+      // ticking down even though the run has ended. Freeze it at the value it had the moment
+      // the run ended by using runEndedAtMs as the reference time instead of currentTimeMs.
+      // m_ResultDisplayEndTimeMs is set to (currentTimeMs + ResultDisplayDurationMs) at the
+      // pass/fail/timeout site, so subtracting recovers the run-end timestamp.
+      const bool inResultHold
+         = m_MenuOptions.m_TrainerOptions.m_ResultDisplayEndTimeMs != 0
+         && currentTimeMs < m_MenuOptions.m_TrainerOptions.m_ResultDisplayEndTimeMs;
+      const int referenceTimeMs = inResultHold
+         ? (m_MenuOptions.m_TrainerOptions.m_ResultDisplayEndTimeMs - TrainerOptions::ResultDisplayDurationMs)
+         : currentTimeMs;
+
       DWORD totalMsPerRun = (m_MenuOptions.m_TrainerOptions.m_MaxSecondsPerRun + m_MenuOptions.m_TrainerOptions.m_CountdownSecondsBeforeRun) * OneSecondMs;
-      DWORD runElapsedTimeMs = currentTimeMs - m_MenuOptions.m_TrainerOptions.m_RunStartTimeMs;
+      DWORD runElapsedTimeMs = referenceTimeMs - m_MenuOptions.m_TrainerOptions.m_RunStartTimeMs;
       printScreenTexts.push_back({ "Time", std::format("{:.2f}s", std::min(float(m_MenuOptions.m_TrainerOptions.m_MaxSecondsPerRun), (totalMsPerRun - runElapsedTimeMs) / float(OneSecondMs))) });
    }
    else

--- a/src/core/ballhistory.h
+++ b/src/core/ballhistory.h
@@ -363,14 +363,21 @@ public:
       static const int32_t RadiusPercentMinimum = 0;
       static const int32_t RadiusPercentMaximum = 300;
 
+      // In-plane (yaw, around Z) rotation of the pass wall in degrees. 0° = horizontal pass
+      // wall along +X (original behavior). 0..180 covers every unique orientation since a
+      // line segment is symmetric (180° is visually identical to 0° with the ends swapped).
+      static const int32_t PassRotationMinimum = 0;
+      static const int32_t PassRotationMaximum = 180;
+
       Vertex3Ds m_PassPosition;
       float m_PassRadiusPercent;
+      float m_PassRotationDegrees;
 
       Vertex3Ds m_OpeningPositionLeft;
       Vertex3Ds m_OpeningPositionRight;
 
       BallCorridorOptionsRecord();
-      BallCorridorOptionsRecord(const Vertex3Ds &passPosition, float passRadiusPercent, const Vertex3Ds &openingLeft, const Vertex3Ds &openingRight);
+      BallCorridorOptionsRecord(const Vertex3Ds &passPosition, float passRadiusPercent, float passRotationDegrees, const Vertex3Ds &openingLeft, const Vertex3Ds &openingRight);
    };
 
    struct RunRecord
@@ -724,6 +731,7 @@ private:
          MenuStateType_Trainer_SelectBallCorridorComplete,
          MenuStateType_Trainer_SelectBallCorridorPassLocation,
          MenuStateType_Trainer_SelectBallCorridorPassWidth,
+         MenuStateType_Trainer_SelectBallCorridorPassRotation,
          MenuStateType_Trainer_SelectBallCorridorOpeningLeftLocation,
          MenuStateType_Trainer_SelectBallCorridorOpeningRightLocation,
          MenuStateType_Trainer_SelectGameplayDifficultyOptions,
@@ -875,6 +883,7 @@ private:
    static const char *TrainerModeBallFailAssociationsKeyName;
    static const char *TrainerModeBallCorridorPassPosition3DKeyName;
    static const char *TrainerModeBallCorridorPassRadiusPercentKeyName;
+   static const char *TrainerModeBallCorridorPassRotationDegreesKeyName;
    static const char *TrainerModeBallCorridorOpeningPositionLeft3DKeyName;
    static const char *TrainerModeBallCorridorOpeningPositionRight3DKeyName;
    

--- a/src/core/ballhistory.h
+++ b/src/core/ballhistory.h
@@ -475,6 +475,13 @@ public:
    static const int32_t CountdownSecondsBeforeRunMaximum = 5;
    int32_t m_CountdownSecondsBeforeRun;
 
+   // When the user exits the BH menu (control→non-control) and CountdownSecondsBeforeRun is 0,
+   // a one-time 1-second delay is forced before the run starts so the user has a moment to
+   // settle in. Set in SetControl(false), cleared when the run transitions from countdown to
+   // active. Run-to-run transitions (no menu involvement) do NOT trigger the delay.
+   bool m_ForceInitialDelayOnControlExit;
+   static const int32_t ForcedInitialDelayMs = 1000;
+
    std::vector<BallStartOptionsRecord> m_BallStartOptionsRecords;
    std::size_t m_BallStartOptionsRecordsSize;
    std::vector<BallEndOptionsRecord> m_BallPassOptionsRecords;


### PR DESCRIPTION
Three atomic commits to bring development -> integration.

## status-vpx skill — output redesign

Major iteration on the bundled status reporter:

- **Branch stack** is now four `source -> target` flow rows with hardcoded plain-English hints ("upstream has stuff master hasnt pulled in yet"). Last row flipped (`integration <- development`) to anchor integration on the left.
- **2-line LLM-synthesized digests** per non-zero flow (max 120 chars per line). Script emits a `[range: ...]` hint; Claude runs `git log <range>` at presentation time and writes themed summaries.
- **Origin sync** is a 3-column table (Branch | Origin status | What to do) with plain-English next-step guidance from a new `origin_action()` helper.
- **Working tree** is a 3-column table; third column gets a 1-sentence per-file description from Claude via `git diff <file>` at presentation.
- **Section order**: CI status -> Branch stack -> Working tree -> Open PRs.
- Dead code removed (`emit_branch_node`, `get_diffs_bullets`, `mk_marker`).
- SKILL.md fully synced so the skill works self-contained in fresh chats.

## .gitignore additions

- `build_*.log` (helper-script outputs)
- `*.jks`, `*.keystore` (Android signing — secrets, never check in)
- `.claude/*.lock` (scheduled-task lockfile)

## CLAUDE.md cabinet-rotation universal fix doc

Documents `ViewCabRotation = 90` as the universal cabinet-orientation override that fixes both Legacy-mode tables (ROTF=270, ~98% of tables) and Window-mode tables with the broken-author bug (ROTF=0). Includes ViewSetup.cpp explanation, triage guidance, and a VPX tag table for diagnosing outliers via binary grep on `GameStg/GameData`.

## Notes

- Read-only changes: skill, gitignore, docs. No engine/source code touched.
- **Do not merge yet** — leaving open for review and CI watch.