### PR TITLE
Cabinet autofit: walk-down glass-height calibration + Scale/Cap knobs + Custom/Standard toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,10 +127,20 @@ $env:ANDROID_HOME = "C:\Users\gary.brown\AppData\Local\Android\Sdk"
 
 # Install + run
 adb install -r standalone\android\app\build\outputs\apk\mobile\debug\VPinballX_BGFX-*-mobile-debug.apk
-adb shell am start -n org.vpinball.vpinball_bgfx/org.vpinball.app.MainActivity
+adb shell am start -n org.vpinball.vpinball_bgfx/org.vpinball.app.VPinballActivity
 ```
 
 In-app, set Vulkan + 1080×2400 + FullScreen in `VPinballX.ini` before running the table. The ralph loop in `_research/android-x86_64/_ralph_iteration.sh` documents the full sequence end-to-end.
+
+### Troubleshooting: emulator gets slow after a long session
+
+After ~1 hour of use — especially if there were any native crashes (SIGSEGV/SIGABRT/SIGFPE) — frame times degrade dramatically (16ms → 200-2700ms per `dumpsys gfxinfo`). Cause: emulator state accumulates leaked GPU resources, surface/swapchain refcount imbalances, fragmented heap, and stuck tombstone-collection threads. Stopping gradle daemons and shutting down WSL does **not** help (Windows reallocates immediately). The fix:
+
+1. Kill QEMU/emulator: `& adb emu kill; Stop-Process -Name qemu*,emulator* -Force`
+2. Relaunch fresh (`-no-snapshot`, ~30 sec to boot)
+3. **Do NOT `adb install -r` the APK** — this wipes BGFX's compiled-shader cache and you'll pay for re-JIT on first encounter. Just relaunch the existing install with `am start`.
+
+If slowness persists after a clean restart with cache preserved, then suspect host pressure or BGFX/Vulkan path issues. Otherwise, restarting on this loop is normal hygiene during long debug sessions.
 
 ### Research/debug helpers (local-only, not committed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,14 @@ git checkout -- third-party/
 ```
 
 ### Build tips
-- After upstream merges, re-run `make/create_vs_solution.bat` to regenerate VS project files
-- When changing headers (especially `def.h`, `stdafx.h`, `ballhistory.h`), delete ALL `.obj` files: `rm -rf .build/obj/vpx/Debug-x64/*.obj`
+- After upstream merges, re-run `make/create_vs_solution.bat` to regenerate VS project files. **Symptom of skipping**: `error C1083: Cannot open source file ... BAMView.cpp` — the templated vcxproj is stale and references files upstream deleted.
+- When changing headers (especially `def.h`, `stdafx.h`, `ballhistory.h`, `Settings_properties.inl`), delete ALL `.obj` files: `rm -rf .build/obj/vpx/Debug-x64/*.obj`
 - Force relink by also deleting the exe: `rm -f .build/bin/vpx/Debug-x64/VPinballX64.exe`
-- Build just vpx without plugins: add `-p:BuildProjectReferences=false` to MSBuild
-- MSBuild from CLI: `"/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" ".build/vsproject/vpx.vcxproj" -p:Configuration=Debug -p:Platform=x64 -m`
+- Build via the **solution** for non-Debug configs (Release_BGFX, Release_GL): `MSBuild .build/vsproject/VisualPinball.sln -t:vpx -p:Configuration=Release_BGFX -p:Platform=x64`. **Building the vcxproj directly fails** with `error MSB8013: This project doesn't contain the Configuration and Platform combination of Release_BGFX|x64` for every plugin — the sln config-map translates `Release_BGFX|x64` → `Release|x64` for plugins, but the standalone vcxproj doesn't.
+- Build just vpx without plugins: add `-p:BuildProjectReferences=false` to MSBuild (works for Debug-x64; for Release_BGFX, use `-t:vpx` on the sln instead — same effect, correct config mapping)
+- Cap parallelism at `-m:9` (75% of 12 cores) to avoid heap-limit C1076 errors
+- MSBuild from CLI: `"/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" ".build/vsproject/VisualPinball.sln" -t:vpx -p:Configuration=Release_BGFX -p:Platform=x64 -m:9`
+- **Deploy convention**: build artifact at `.build/bin/vpx/<Config>-x64/VPinballX_BGFX64.exe` → cabinet at `Z:\visual pinball\VPinballX_BGFX64_BH.exe` (rename adds `_BH` suffix at deploy time)
 
 ### CMake Build (windows-x64)
 ```
@@ -206,18 +209,74 @@ When upstream changes conflict with Ball History integration points:
 - **In-game settings UI**: Press F12 while playing (replaces old Video Options dialog)
 - **Ball History debug log**: `<exe folder>/BallHistory/ballhistory_debug.log` (Debug builds only)
 
-### Cabinet table-rotation universal fix (`ViewCabRotation = 90.000000`)
+### Cabinet ini recovery recipe (known-good baseline as of 2026-05-14)
 
-In Gary's `VPinballX.ini` `[TableOverride]` section, `ViewCabRotation = 90.000000` is the universal cabinet-orientation fix. Empirically verified across a 500-table audit — produces the correct landscape orientation for **both** of the rotation regimes that exist in the wild:
+Minimum config needed to recover a working cabinet from a blank ini. Everything else can stay at code defaults; VPX repopulates auto-state on first launch.
 
-- **Legacy-mode tables** (~98% of tables, ROTF=270 baked in `.vpx`)
-- **Window-mode tables with the broken-author bug** (ROTF=0 baked, e.g. White Water v.1.2, 4 Queens, World Poker Tour, Space Station VPW, Junior, Defender VPW, Central Park)
+```ini
+[Player]
+; --- View mode + autofit (the unlock) ---
+BGSet                = 1                  ; Cabinet view set
+CabinetAutofitMode   = 2                  ; Fit Screen — autofit derives per-table values
+FullScreen           = 1
 
-**Why one value fixes both modes** (`src/renderer/ViewSetup.cpp`):
-- Window mode (`GetRotation`, line 302-306) auto-adds `270°` for landscape viewports before applying the user value: setting 90 → effective `(270 + 90) % 360 = 0°` (no rotation, table fills landscape directly because Window mode already maps physical screen cm to playfield).
-- Legacy mode (line 309-310, plus `MatrixScale(mSceneScaleX, -mSceneScaleY, -mSceneScaleZ)` Y/Z-axis flip in `ComputeMVP` line 447) applies the user value through a flipped coordinate system, so 90° in legacy is not the geometric inverse of 270° in window — the combined transforms produce equivalent visual orientations on a landscape display.
+; --- Display target ---
+PlayfieldDisplay     = 1
+PlayfieldWidth       = 3840
+PlayfieldHeight      = 2160
+RefreshRate          = 144
+GfxBackend           = Direct3D11
+SyncMode             = 1                  ; Hardware V-Sync. NOT 3 — Frame Pacing stutters.
+MaxFramerate         = -1.0               ; Uncapped; V-Sync drives cadence
 
-**Practical implication**: when triaging a table that renders "wrong orientation" on the cabinet, **first** assume the global override already covers it. Per-table sidecar `.ini` files (`<table>.ini` next to `<table>.vpx` with `[TableOverride] ViewCabRotation = X`) are only needed for genuine outliers — not the routine ROTF=0 author bug.
+; --- Physical cabinet geometry (autofit math reads these) ---
+ScreenWidth          = 95.889999          ; cm — measured TV display area
+ScreenHeight         = 53.939999
+ScreenInclination    = 0.0
+ScreenPlayerX        = 0.0
+ScreenPlayerY        = 0.0
+ScreenPlayerZ        = 70.0               ; cm eye height above playfield bottom edge
+
+; --- Anti-stretch + max quality push (Gary's RTX-class GPU) ---
+BallAntiStretch      = 1
+AAFactor             = 1.0                ; 100% (no supersample); 1.5 was too soft, 2.0 broke 144Hz
+MSAASamples          = 3                  ; 8 samples — max
+FXAA                 = 7                  ; Quality FAAA — max
+Sharpen              = 2                  ; Bilateral CAS — max
+SSRefl               = 1                  ; Additive screen-space reflection — max
+
+[TableOverride]
+ViewCabMode          = 2                  ; Window mode (required for autofit)
+ViewCabRotation      = 0.0                ; Post-Vincent autofit fix — see history below
+ViewCabWindowTopScale = 1.0               ; Calibrate per-cabinet via F12; ~0.7 on Gary's rig
+```
+
+Other quality knobs (`PFReflection`, `AlphaRampAccuracy`, `MaxTexDimension`, `DynamicAO`, `ForceAnisotropicFiltering`) are already at max in their **code defaults** — no ini override needed.
+
+### `ViewCabWindowTopScale` — fork-local autofit calibration knob (added 2026-05-13)
+
+Multiplier applied to autofit-computed `WindowTopZOfs` so the top-glass-plane bias on Gary's cabinet can be trimmed **proportionally across all tables**. Default `1.0` = no-op. `0.7` trims every table's top by 30%, preserving per-table variation (short tables get small trim, tall tables get large trim — what an offset can't do).
+
+- Property defs in `src/core/Settings_properties.inl` (DT/FSS/Cab triple at lines ~684, ~705, ~726).
+- Multiplier applied in `src/renderer/ViewSetup.cpp` `ApplyTableOverrideSettings` (line 185-186).
+- F12 → Point Of View slider in `src/ui/live/ingameui/PointOfViewSettingsPage.cpp` (visible only in autofit modes; setter applies incremental ratio `mWindowTopZOfs *= (v/prev)` — **does NOT** call `SetWindowAutofit` because that clobbers every other slider's transient state).
+- Page's `SaveMode` upgraded from `Table` to `Both` so changes can be saved globally OR per-table.
+
+Fork-local feature — upstream-worthy PR but not yet filed.
+
+### Cabinet rotation: post-Vincent regime change (April 29, 2026)
+
+**Current rule**: `ViewCabRotation = 0.0` in `[TableOverride]` is correct for Gary's landscape cabinet under post-Vincent-fix builds.
+
+Upstream commit `89a84494c "Fix cabinet autofit on landscape display"` (Vincent, April 29) changed `SetWindowAutofit` to derive landscape rotation itself — removing the `mViewportRotation = GetRotation(1080*aspect, 1080)` line and replacing with `mViewportRotation = 0.f`. Plus an axis-swap in the vertical-offset dichotomy search (`-bottomFlipper.x` for landscape vs `bottomFlipper.y` for portrait).
+
+**Symptom of getting this wrong**: with `ViewCabRotation = 90` (the old empirically-verified value) on a post-fix build, the table renders **sideways**. Rollback to a pre-fix build OR change ini to `0.0` — both fix it.
+
+**Historical context** (pre-Vincent regime, kept for reference only — no longer the current rule):
+
+> `ViewCabRotation = 90.000000` was the universal cabinet-orientation fix, empirically verified across a 500-table audit. Produced the correct landscape orientation for both Legacy-mode tables (ROTF=270 baked in `.vpx`) and Window-mode tables with the broken-author bug (ROTF=0 baked, e.g. White Water v1.2, 4 Queens, World Poker Tour, Space Station VPW). Worked because Window mode's `GetRotation` auto-adds 270° for landscape viewports: `(270 + 90) % 360 = 0` effective — no rotation, table fills landscape directly.
+
+**Practical implication**: when triaging a "wrong orientation" report, first check whether the build is pre- or post-Vincent. If post-Vincent, use 0. If pre-Vincent, use 90. Per-table sidecar `.ini` files are only needed for genuine outliers.
 
 **Limitation**: only verified on Gary's landscape cabinet (4K landscape physical, BGSet=1, ScreenWidth=95.9 / Height=53.9 cm). Different cabinet geometries (portrait monitor, head-tracking, VR) may need different values.
 

--- a/src/core/Settings_properties.inl
+++ b/src/core/Settings_properties.inl
@@ -681,6 +681,11 @@ PropFloatDyn(TableOverride, ViewDTVOfs, "Vertical Offset"s, "Vertical offset of 
 PropFloatDyn(TableOverride, ViewDTWindowTop, "Window Top Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the top of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
 PropFloatDyn(
    TableOverride, ViewDTWindowBot, "Window Bottom Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the bottom of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
+PropFloatDyn(TableOverride, ViewDTWindowTopScale, "Window Top Z Scale"s, "Multiplier applied to the computed top glass height (calibration for autofit bias)"s, 0.5f, 1.5f, 1.f);
+PropFloatDyn(TableOverride, ViewDTWindowTopCap, "Window Top Z Cap"s, "Hard maximum on the autofit-computed top glass height; values above are clipped. Set high to disable."s, CMTOVPU(1.f), CMTOVPU(50.f), CMTOVPU(50.f));
+PropEnumDyn(TableOverride, ViewDTUseCustomAutofit, "Custom Fit-Screen Autofit"s,
+   "When 'Custom' (default), apply walk-down + max-tilt algorithm tuned for landscape cabinets. When 'Standard', use vanilla upstream Fit-Screen autofit."s,
+   int, 1, "Standard"s, "Custom"s);
 PropFloatSteppedDyn(TableOverride, ViewDTRotation, "Viewport Rotation"s, ""s, 0.f, 360.f, 90.0f, 0.f);
 
 PropEnumDyn(TableOverride, ViewFSSMode, "View mode"s,
@@ -701,6 +706,11 @@ PropFloatDyn(
    TableOverride, ViewFSSWindowTop, "Window Top Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the top of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
 PropFloatDyn(
    TableOverride, ViewFSSWindowBot, "Window Bottom Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the bottom of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
+PropFloatDyn(TableOverride, ViewFSSWindowTopScale, "Window Top Z Scale"s, "Multiplier applied to the computed top glass height (calibration for autofit bias)"s, 0.5f, 1.5f, 1.f);
+PropFloatDyn(TableOverride, ViewFSSWindowTopCap, "Window Top Z Cap"s, "Hard maximum on the autofit-computed top glass height; values above are clipped. Set high to disable."s, CMTOVPU(1.f), CMTOVPU(50.f), CMTOVPU(50.f));
+PropEnumDyn(TableOverride, ViewFSSUseCustomAutofit, "Custom Fit-Screen Autofit"s,
+   "When 'Custom' (default), apply walk-down + max-tilt algorithm tuned for landscape cabinets. When 'Standard', use vanilla upstream Fit-Screen autofit."s,
+   int, 1, "Standard"s, "Custom"s);
 PropFloatSteppedDyn(TableOverride, ViewFSSRotation, "Viewport Rotation"s, ""s, 0.f, 360.f, 90.0f, 0.f);
 
 PropEnumDyn(TableOverride, ViewCabMode, "View mode"s,
@@ -721,6 +731,11 @@ PropFloatDyn(
    TableOverride, ViewCabWindowTop, "Window Top Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the top of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
 PropFloatDyn(
    TableOverride, ViewCabWindowBot, "Window Bottom Z Ofs."s, "Distance between the 'window' (i.e. the screen) at the bottom of the playfield"s, CMTOVPU(0.f), CMTOVPU(50.f), CMTOVPU(0.f));
+PropFloatDyn(TableOverride, ViewCabWindowTopScale, "Window Top Z Scale"s, "Multiplier applied to the computed top glass height (calibration for autofit bias)"s, 0.5f, 1.5f, 1.f);
+PropFloatDyn(TableOverride, ViewCabWindowTopCap, "Window Top Z Cap"s, "Hard maximum on the autofit-computed top glass height; values above are clipped. Set high to disable."s, CMTOVPU(1.f), CMTOVPU(50.f), CMTOVPU(50.f));
+PropEnumDyn(TableOverride, ViewCabUseCustomAutofit, "Custom Fit-Screen Autofit"s,
+   "When 'Custom' (default), apply walk-down + max-tilt algorithm tuned for landscape cabinets. When 'Standard', use vanilla upstream Fit-Screen autofit (raw max-Z, no tilt clamp). Cap and Scale knobs apply in both modes."s,
+   int, 1, "Standard"s, "Custom"s);
 PropFloatSteppedDyn(TableOverride, ViewCabRotation, "Viewport Rotation"s, ""s, 0.f, 360.f, 90.0f, 0.f);
 
 PropFloatDyn(TableOverride, Difficulty, "Difficulty"s, "Overall difficulty (affects slope, flipper size, ball trajectories scattering,...)"s, 0.f, 1.f, 1.f);

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1295,6 +1295,10 @@ void Player::SetCabinetAutoFitMode(int mode)
    {
       Vertex3Ds playerPos(m_ptable->m_settings.GetPlayer_ScreenPlayerX(), m_ptable->m_settings.GetPlayer_ScreenPlayerY(), m_ptable->m_settings.GetPlayer_ScreenPlayerZ());
       m_ptable->GetViewSetup().SetWindowAutofit(m_ptable, playerPos, m_renderer->GetDisplayAspectRatio(), m_cabinetAutoFitPos, m_cabinetAutoFitMode == 2, [](string) { });
+      m_ptable->GetViewSetup().ApplyTableOverrideSettings(m_ptable->m_settings, m_ptable->GetViewMode());
+      // ApplyTableOverrideSettings can mutate mWindowTopZOfs/Bot via cap/scale; recompute view
+      // position so mViewZ reflects the post-cap glass plane (otherwise camera drifts).
+      m_ptable->GetViewSetup().SetViewPosFromPlayerPosition(m_ptable, playerPos, m_ptable->m_settings.GetPlayer_ScreenInclination());
    }
 }
 
@@ -1305,6 +1309,8 @@ void Player::SetCabinetAutoFitPos(float pos)
    {
       Vertex3Ds playerPos(m_ptable->m_settings.GetPlayer_ScreenPlayerX(), m_ptable->m_settings.GetPlayer_ScreenPlayerY(), m_ptable->m_settings.GetPlayer_ScreenPlayerZ());
       m_ptable->GetViewSetup().SetWindowAutofit(m_ptable, playerPos, m_renderer->GetDisplayAspectRatio(), m_cabinetAutoFitPos, m_cabinetAutoFitMode == 2, [](string) { });
+      m_ptable->GetViewSetup().ApplyTableOverrideSettings(m_ptable->m_settings, m_ptable->GetViewMode());
+      m_ptable->GetViewSetup().SetViewPosFromPlayerPosition(m_ptable, playerPos, m_ptable->m_settings.GetPlayer_ScreenInclination());
    }
 }
 

--- a/src/input/ButtonMapping.h
+++ b/src/input/ButtonMapping.h
@@ -46,6 +46,7 @@ public:
       , m_isPressed(other.m_isPressed)
       , m_axisThreshold(other.m_axisThreshold)
       , m_isAxisReversed(other.m_isAxisReversed)
+      , m_lastChangeArrivalUs(other.m_lastChangeArrivalUs)
    {
       if (m_eventManager)
          m_eventManager->Register(this);
@@ -64,6 +65,7 @@ public:
          m_isPressed = other.m_isPressed;
          m_axisThreshold = other.m_axisThreshold;
          m_isAxisReversed = other.m_isAxisReversed;
+         m_lastChangeArrivalUs = other.m_lastChangeArrivalUs;
          m_buttonCaptureStartMs = other.m_buttonCaptureStartMs;
          m_buttonCapturePos = other.m_buttonCapturePos;
          if (m_eventManager)
@@ -100,19 +102,20 @@ public:
       return ButtonMapping(eventManager, mappingHandler, m_deviceId, m_axisOrButtonId, m_axisThreshold, m_isAxisReversed);
    }
 
-   void SetAxisPosition(float position)
+   void SetAxisPosition(float position, uint64_t sdlArrivalUs = 0)
    {
       if (m_isAxisReversed)
-         SetPressed(position <= m_axisThreshold);
+         SetPressed(position <= m_axisThreshold, sdlArrivalUs);
       else
-         SetPressed(position >= m_axisThreshold);
+         SetPressed(position >= m_axisThreshold, sdlArrivalUs);
    }
 
-   void SetPressed(bool pressed)
+   void SetPressed(bool pressed, uint64_t sdlArrivalUs = 0)
    {
       if (pressed != m_isPressed)
       {
          m_isPressed = pressed;
+         m_lastChangeArrivalUs = sdlArrivalUs;
          if (m_mappingHandler)
             m_mappingHandler->OnInputChanged(this);
       }
@@ -122,6 +125,9 @@ public:
    {
       return m_isPressed;
    }
+
+   // Timestamp of the SDL event that caused the last state change, in VPX usec() timebase. 0 if unknown.
+   uint64_t GetLastChangeArrivalUs() const { return m_lastChangeArrivalUs; }
 
    uint16_t GetDeviceId() const { return m_deviceId; }
    uint16_t GetAxisOrButtonId() const { return m_axisOrButtonId; }
@@ -143,4 +149,5 @@ private:
    bool m_isPressed;
    float m_axisThreshold;
    bool m_isAxisReversed;
+   uint64_t m_lastChangeArrivalUs = 0;
 };

--- a/src/input/InputAction.cpp
+++ b/src/input/InputAction.cpp
@@ -189,7 +189,7 @@ void InputAction::SetDirectState(int slot, bool state)
    }
 }
 
-void InputAction::OnInputChanged(ButtonMapping*)
+void InputAction::OnInputChanged(ButtonMapping* mapping)
 {
    const bool wasPressed = m_isPressed;
    m_isPressed = false;
@@ -218,6 +218,10 @@ void InputAction::OnInputChanged(ButtonMapping*)
    if (m_isPressed != wasPressed)
    {
       m_eventManager->OnInputActionStateChanged(this);
+      // Stamp SDL arrival (from the mapping that just flipped) BEFORE m_lastOnChangeUs so PerfUI's "Components"
+      // line can compute SDL->Act = m_lastOnChangeUs - m_sdlArrivalUs. Direct-state path passes mapping=nullptr;
+      // m_sdlArrivalUs stays 0 in that case and PerfUI shows '-'.
+      m_sdlArrivalUs = mapping ? mapping->GetLastChangeArrivalUs() : 0;
       m_lastOnChangeUs = usec();
       m_onStateChange(*this, wasPressed, m_isPressed);
       if (m_isPressed && m_repeatPeriodUs >= 0)

--- a/src/input/InputAction.h
+++ b/src/input/InputAction.h
@@ -35,6 +35,9 @@ public:
    bool IsPressed() const { return m_isPressed; }
    void SetPressed(bool isPressed) { m_isPressed = isPressed; }
    uint64_t GetLastStateChange() const { return m_lastOnChangeUs; }
+   // SDL event arrival time (in VPX usec()) for the mapping that caused the most recent state change. 0 if unknown
+   // (e.g. direct-state path with no SDL origin, or pre-event startup).
+   uint64_t GetSdlArrival() const { return m_sdlArrivalUs; }
 
    void SetActionId(unsigned int id) { m_actionId = id; }
    unsigned int GetActionId() const { return m_actionId; }
@@ -61,6 +64,7 @@ private:
    vector<bool> m_directStates;
    bool m_isPressed = false;
    uint64_t m_lastOnChangeUs = 0;
+   uint64_t m_sdlArrivalUs = 0;
    int64_t m_repeatPeriodUs = -1;
    unsigned int m_actionId = 0xFFFFFFFF;
 };

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -535,10 +535,15 @@ void InputManager::PushButtonEvent(uint16_t deviceId, uint16_t buttonId, uint64_
    if (deviceId == m_keyboardDeviceId && ImGui::GetIO().WantCaptureKeyboard)
       return;
 
+   // Convert SDL ns timestamp into VPX usec() timebase so latency diagnostics in PerfUI can subtract directly.
+   // OpenPinDev callers pass a firmware clock (not SDL) — converted value is meaningless for that path,
+   // but it's a debug-only display and OpenPinDev isn't Gary's primary input route.
+   const uint64_t sdlArrivalUs = sdl_ns_to_usec(timestampNs);
+
    uint32_t id = deviceId << 16 | buttonId;
    if (auto it = m_buttonMappings.find(id); it != m_buttonMappings.end())
       for (ButtonMapping* mapping : it->second)
-         mapping->SetPressed(isPressed);
+         mapping->SetPressed(isPressed, sdlArrivalUs);
 
    // Special handling for keyboard events to trigger custom KeyDown/KeyUp events in the script based on Windows DirectInput key codes
    if (deviceId == m_keyboardDeviceId && !m_player->m_liveUI->IsInGameUIOpened())
@@ -578,8 +583,11 @@ void InputManager::PushAxisEvent(uint16_t deviceId, uint16_t axisId, uint64_t ti
          mapping->SetAxisPosition(timestampNs, position);
 
    if (auto it = m_buttonMappings.find(id); it != m_buttonMappings.end())
+   {
+      const uint64_t sdlArrivalUs = sdl_ns_to_usec(timestampNs);
       for (ButtonMapping* mapping : it->second)
-         mapping->SetAxisPosition(position);
+         mapping->SetAxisPosition(position, sdlArrivalUs);
+   }
 
    for (const auto& listener : m_axisListeners)
       listener();

--- a/src/parts/pintable.cpp
+++ b/src/parts/pintable.cpp
@@ -3031,13 +3031,16 @@ const wstring& PinTable::GetCollectionNameByElement(const ISelect * const elemen
     return emptyString;
 }
 
-Vertex2D PinTable::EvaluateGlassHeight() const
+Vertex2D PinTable::EvaluateGlassHeight(bool useWalkDown) const
 {
    Vertex2D result(0.f, 0.f);
    constexpr float marginX = INCHESTOVPU(1.0f);
    constexpr float marginY = INCHESTOVPU(0.1f);
    constexpr float marginZ = INCHESTOVPU(0.1f);
-   auto submitVertex = [this, &result](const Vertex3Ds &v)
+   // Collect every accepted back-band vertex Z so the walk-down pass below can locate the top of
+   // real playable geometry while ignoring phantom 3D-backbox decoration sitting above an air gap.
+   std::vector<float> backBandZ; // every accepted back-edge v.z (in VPU)
+   auto submitVertex = [this, &result, &backBandZ](const Vertex3Ds &v)
    {
       // Reject vertices below, or outside left and right limits
       if (v.z < -marginZ || v.x < m_left - marginX || v.x > m_right + marginX)
@@ -3047,7 +3050,10 @@ Vertex2D PinTable::EvaluateGlassHeight() const
          result.x = max(result.x, v.z);
       // Top area (y = 0)
       if (v.y >= m_top - marginY && v.y <= m_top + marginY && v.z <= INCHESTOVPU(12.f))
+      {
          result.y = max(result.y, v.z);
+         backBandZ.push_back(v.z);
+      }
    };
    auto intersect2D = [](const RenderVertex &v1, const RenderVertex &v2, float y)
    {
@@ -3163,6 +3169,47 @@ Vertex2D PinTable::EvaluateGlassHeight() const
    {
       PLOGI << "Evaluated glass height to " << VPUTOINCHES(result.x) << "\" (" << upperEditableX->GetName() << ") - " << VPUTOINCHES(result.y) << "\" (" << upperEditableY->GetName() << ')';
    }
+
+   // Walk-down pass (fork-local): raw max-Z is fooled by phantom 3D-backbox decoration that modern
+   // table meshes bake well above the real playfield (e.g. a lighting-variant primitive cluster
+   // sitting ~15 cm above the highest real ramp). Bucket the back-band vertices into 0.5 cm bins,
+   // drop sparse bins, then walk from the highest significant bin downward and stop at the first one
+   // whose next-lower significant bin is within kGapThresholdCm — i.e. the top of a continuous body
+   // of real geometry. A lone significant bin is taken as-is.
+   constexpr float kGapThresholdCm = 10.0f; // air gap above which a higher bin is treated as decoration
+   constexpr int kMinClusterVerts = 5;      // min vertices for a 0.5 cm bin to count as real geometry
+   const float maxZTopVPU = result.y;
+   float walkDownTopVPU = maxZTopVPU;
+   if (!backBandZ.empty())
+   {
+      std::map<int, int, std::greater<int>> buckets;
+      for (float z : backBandZ)
+         buckets[(int)std::round(VPUTOCM(z) * 2.0f)]++; // 0.5 cm buckets
+      std::vector<float> sig_cm;
+      for (const auto& [bin, count] : buckets)
+         if (count >= kMinClusterVerts) sig_cm.push_back(bin * 0.5f);
+      if (sig_cm.size() == 1)
+         walkDownTopVPU = CMTOVPU(sig_cm[0]);
+      else if (sig_cm.size() >= 2)
+      {
+         walkDownTopVPU = CMTOVPU(sig_cm.back()); // fallback if no anchored cluster found
+         for (size_t i = 0; i + 1 < sig_cm.size(); i++)
+         {
+            if (sig_cm[i] - sig_cm[i + 1] <= kGapThresholdCm)
+            {
+               walkDownTopVPU = CMTOVPU(sig_cm[i]);
+               break;
+            }
+         }
+      }
+   }
+   // Sparse-table fallback: if the walk-down collapsed to near the floor (a back wall with fewer
+   // than kMinClusterVerts vertices per bin) but raw max-Z found real geometry higher up, trust the
+   // raw max-Z so the back of sparse tables is not clipped.
+   if (VPUTOCM(walkDownTopVPU) < 3.0f && VPUTOCM(maxZTopVPU) > 5.0f)
+      walkDownTopVPU = maxZTopVPU;
+   // Custom mode returns the walk-down result; Standard mode returns vanilla upstream raw max-Z.
+   result.y = useWalkDown ? walkDownTopVPU : maxZTopVPU;
    return result;
 }
 

--- a/src/parts/pintable.h
+++ b/src/parts/pintable.h
@@ -546,7 +546,7 @@ public:
 
    bool GetCollectionIndex(const ISelect *const element, int &collectionIndex, int &elementIndex);
 
-   Vertex2D EvaluateGlassHeight() const;
+   Vertex2D EvaluateGlassHeight(bool useWalkDown = true) const;
 
    void LockElements();
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -1605,7 +1605,7 @@ void Renderer::RenderStaticPrepass()
       int progress = 70 + (((30 * (n_iter + 1 - iter)) / (n_iter + 1)));
       g_pplayer->m_progressDialog.SetProgress("Prerendering Static Parts..."s, progress);
 #ifdef __LIBVPINBALL__
-      VPinballLib::ProgressData progressData = { (n_iter - iter) * 100 / n_iter };
+      VPinballLib::ProgressData progressData = { n_iter > 0 ? ((n_iter - iter) * 100 / n_iter) : 100 };
       VPinballLib::VPinballLib::SendEvent(VPINBALL_EVENT_PRERENDERING, &progressData);
 #endif
       m_renderDevice->m_curDrawnTriangles = 0;

--- a/src/renderer/ViewSetup.cpp
+++ b/src/renderer/ViewSetup.cpp
@@ -45,7 +45,7 @@ vec3 ViewSetup::GetPlayerPositionFromViewPos(const PinTable* const table, const 
 
 void ViewSetup::SetWindowAutofit(const PinTable* const table, const vec3& playerPos, const float aspect, const float flipperPos, const bool allowNonUniformStretch, const std::function<void(string)>& glassNotification)
 {
-   const Settings& settings = table->m_settings; 
+   const Settings& settings = table->m_settings;
    const float screenWidth = settings.GetPlayer_ScreenWidth();
    const float screenHeight = settings.GetPlayer_ScreenHeight();
    if (screenWidth <= 1.f || screenHeight <= 1.f)
@@ -54,26 +54,21 @@ void ViewSetup::SetWindowAutofit(const PinTable* const table, const vec3& player
       return;
    }
 
-   // Evaluate glass heights by analyzing table elements bounds, eventually reporting discrepancies
-   Vertex2D glass = table->EvaluateGlassHeight();
-   float bottomHeight = glass.x;
-   float topHeight = glass.y;
+   // Custom Fit-Screen autofit (fork-local, default on): EvaluateGlassHeight runs the walk-down
+   // pass that locates the top of real geometry while ignoring phantom 3D-backbox decoration, and
+   // below we apply a max-tilt clamp. With the toggle on "Standard", EvaluateGlassHeight returns
+   // vanilla raw max-Z and the tilt clamp is skipped — i.e. the unmodified upstream Fit-Screen
+   // result. The Scale/Cap calibration knobs in ApplyTableOverrideSettings layer on in both modes.
+   const bool useCustomAutofit = settings.GetInt(Settings::m_propTableOverride_ViewCabUseCustomAutofit) != 0;
+   const Vertex2D glass = table->EvaluateGlassHeight(useCustomAutofit);
+   const float bottomHeight = glass.x;
+   const float topHeight = glass.y;
    if (table->m_glassTopHeight != table->m_glassBottomHeight)
-   {
-      // If table already define a glass height, use it  (detected by the glass not being horizontal which was the default in previous version),
-      // We compare and propose the value to the user if there is a large enough difference
-      if (VPUTOINCHES(fabs(topHeight - table->m_glassTopHeight)) > 1.f || VPUTOINCHES(fabs(bottomHeight - table->m_glassBottomHeight)) > 1.f)
-      {
-         glassNotification(std::format("Glass height was evaluated to {:.2f}cm / {:.2f}cm\nIt differs from the defined glass position {:.2f}cm / {:.2f}cm", VPUTOCM(bottomHeight),
-            VPUTOCM(topHeight), VPUTOCM(table->m_glassBottomHeight), VPUTOCM(table->m_glassTopHeight)));
-      }
-      topHeight = table->m_glassTopHeight;
-      bottomHeight = table->m_glassBottomHeight;
-   }
+      glassNotification(std::format("Author baked glass {:.2f}/{:.2f} cm; using evaluated {:.2f}/{:.2f} cm",
+         VPUTOCM(table->m_glassBottomHeight), VPUTOCM(table->m_glassTopHeight), VPUTOCM(bottomHeight), VPUTOCM(topHeight)));
    else
-   {
-      glassNotification(std::format("Missing glass position guessed to be {:.2f}cm / {:.2f}cm", VPUTOCM(bottomHeight), VPUTOCM(topHeight)));
-   }
+      glassNotification(std::format("No author glass baked; evaluated {:.2f}/{:.2f} cm", VPUTOCM(bottomHeight), VPUTOCM(topHeight)));
+   mGlassWasEvaluated = true;
 
    mMode = VLM_WINDOW;
    mViewHOfs = 0.f;
@@ -82,6 +77,17 @@ void ViewSetup::SetWindowAutofit(const PinTable* const table, const vec3& player
    mSceneScaleY = allowNonUniformStretch ? 1.f : mSceneScaleX;
    mWindowBottomZOfs = bottomHeight;
    mWindowTopZOfs = topHeight;
+
+   if (useCustomAutofit)
+   {
+      // Universal max-tilt clamp: cap the glass slope so a tall evaluated top can't tip the back of
+      // the playfield away from the player. tan(2°) leaves naturally-shallow tables untouched while
+      // pulling steep ones down.
+      constexpr float kMaxTiltRad = 0.0349f; // tan(2°)
+      const float maxTopForTilt = mWindowBottomZOfs + kMaxTiltRad * table->m_bottom;
+      if (mWindowTopZOfs > maxTopForTilt)
+         mWindowTopZOfs = maxTopForTilt;
+   }
 
    SetViewPosFromPlayerPosition(table, playerPos, table->m_settings.GetPlayer_ScreenInclination());
 
@@ -182,8 +188,30 @@ void ViewSetup::ApplyTableOverrideSettings(const Settings& settings, const ViewS
    mFOV = getFloat(mFOV, Settings::m_propTableOverride_ViewDTFOV, Settings::m_propTableOverride_ViewFSSFOV, Settings::m_propTableOverride_ViewCabFOV);
    mViewHOfs = getFloat(mViewHOfs, Settings::m_propTableOverride_ViewDTHOfs, Settings::m_propTableOverride_ViewFSSHOfs, Settings::m_propTableOverride_ViewCabHOfs);
    mViewVOfs = getFloat(mViewVOfs, Settings::m_propTableOverride_ViewDTVOfs, Settings::m_propTableOverride_ViewFSSVOfs, Settings::m_propTableOverride_ViewCabVOfs);
-   mWindowTopZOfs = getFloat(mWindowTopZOfs, Settings::m_propTableOverride_ViewDTWindowTop, Settings::m_propTableOverride_ViewFSSWindowTop, Settings::m_propTableOverride_ViewCabWindowTop);
-   mWindowBottomZOfs = getFloat(mWindowBottomZOfs, Settings::m_propTableOverride_ViewDTWindowBot, Settings::m_propTableOverride_ViewFSSWindowBot, Settings::m_propTableOverride_ViewCabWindowBot);
+   // WindowTop/Bot layering:
+   //   - INI overrides (or live F12 changes) come through getFloat below.
+   //   - The fork-local Scale/Cap calibration knobs apply ONLY when the glass came from autofit
+   //     (mGlassWasEvaluated == true, set by SetWindowAutofit). In Manual mode the author's baked
+   //     WindowTop/Bot are used as-is and the knobs are skipped, so they never touch a table the
+   //     user is positioning by hand.
+   //   - Scale trims the top proportionally, then Cap clips it at an absolute ceiling.
+   //   - Bottom is clamped to top so the glass stays flat-or-sloped-up, never inverted.
+   {
+      const float autofitOrOverrideTop = getFloat(mWindowTopZOfs, Settings::m_propTableOverride_ViewDTWindowTop, Settings::m_propTableOverride_ViewFSSWindowTop, Settings::m_propTableOverride_ViewCabWindowTop);
+      const float autofitOrOverrideBot = getFloat(mWindowBottomZOfs, Settings::m_propTableOverride_ViewDTWindowBot, Settings::m_propTableOverride_ViewFSSWindowBot, Settings::m_propTableOverride_ViewCabWindowBot);
+      if (mGlassWasEvaluated)
+      {
+         const float cap = getFloat(CMTOVPU(50.f), Settings::m_propTableOverride_ViewDTWindowTopCap, Settings::m_propTableOverride_ViewFSSWindowTopCap, Settings::m_propTableOverride_ViewCabWindowTopCap);
+         const float scale = getFloat(1.f, Settings::m_propTableOverride_ViewDTWindowTopScale, Settings::m_propTableOverride_ViewFSSWindowTopScale, Settings::m_propTableOverride_ViewCabWindowTopScale);
+         mWindowTopZOfs = std::min(autofitOrOverrideTop * scale, cap);
+         mWindowBottomZOfs = std::min(autofitOrOverrideBot, mWindowTopZOfs);
+      }
+      else
+      {
+         mWindowTopZOfs = autofitOrOverrideTop;
+         mWindowBottomZOfs = autofitOrOverrideBot;
+      }
+   }
    mLayback = getFloat(mLayback, Settings::m_propTableOverride_ViewDTLayback, Settings::m_propTableOverride_ViewFSSLayback, Settings::m_propTableOverride_ViewCabLayback);
 }
 

--- a/src/renderer/ViewSetup.h
+++ b/src/renderer/ViewSetup.h
@@ -81,4 +81,10 @@ public:
    // Magic Window mode properties
    float mWindowTopZOfs = CMTOVPU(20.0f); // Upper window border Z coordinate, relative to table playfield Z
    float mWindowBottomZOfs = CMTOVPU(7.5f); // Lower window border Z coordinate, relative to table playfield Z
+
+   // True once SetWindowAutofit has evaluated the glass plane (i.e. autofit is active). False in
+   // Manual mode, where the author's baked WindowTop/Bot are used directly. Gates the fork-local
+   // Scale/Cap calibration knobs in ApplyTableOverrideSettings so they only adjust autofit-derived
+   // glass, never a table the user is positioning by hand.
+   bool mGlassWasEvaluated = false;
 };

--- a/src/ui/live/PerfUI.cpp
+++ b/src/ui/live/PerfUI.cpp
@@ -107,7 +107,8 @@ void PerfUI::RenderFPS()
    {
       const ImVec2 inputTextPos = ImGui::GetCursorScreenPos();
       bool hasFlipperLatency = false;
-      const uint64_t lastLeftFlipChange = m_player->m_pininput.GetInputActions()[m_player->m_pininput.GetLeftFlipperActionId()]->GetLastStateChange();
+      const auto& leftAction = m_player->m_pininput.GetInputActions()[m_player->m_pininput.GetLeftFlipperActionId()];
+      const uint64_t lastLeftFlipChange = leftAction->GetLastStateChange();
       const uint64_t lastRightFlipChange = m_player->m_pininput.GetInputActions()[m_player->m_pininput.GetRightFlipperActionId()]->GetLastStateChange();
       if (const uint64_t now = usec(); now < lastLeftFlipChange + 1000000ULL && now > lastRightFlipChange + 1000000ULL)
       {
@@ -120,6 +121,41 @@ void PerfUI::RenderFPS()
                   const double prevAcqToAction = 1e-3 * (static_cast<double>(flipper->GetLastRotateTime() - lastLeftFlipChange) + m_player->m_pininput.m_leftFlipperLastChangePollDelay);
                   const double acqToAction = 1e-3 * static_cast<double>(flipper->GetLastRotateTime() - lastLeftFlipChange);
                   ImGui::Text("Flipper latency: %3.1f - %3.1fms", acqToAction, prevAcqToAction);
+
+                  // Components line: per-press breakdown including the SDL queue piece and the GPU piece that the
+                  // existing line above doesn't show. Act->Phys here equals acqToAction by construction — visible
+                  // equality is the cross-check that the new instrumentation is wired correctly.
+                  const uint64_t sdlArrivalUs = leftAction->GetSdlArrival();
+                  const bool hasSdl = (sdlArrivalUs != 0 && sdlArrivalUs <= lastLeftFlipChange);
+                  const double sdlToActMs = hasSdl ? 1e-3 * static_cast<double>(lastLeftFlipChange - sdlArrivalUs) : 0.0;
+#ifdef ENABLE_BGFX
+                  const uint64_t gpuRawUs = m_player->m_renderer->m_renderDevice->m_lastGPUFrameLength;
+                  const char* gpuLabel = "GPU";
+#else
+                  const uint64_t gpuRawUs = m_player->m_renderProfiler->GetPrev(FrameProfiler::PROFILE_RENDER_FLIP);
+                  const char* gpuLabel = "~GPU";
+#endif
+                  const double gpuMs = 1e-3 * static_cast<double>(gpuRawUs);
+                  const double totalMs = sdlToActMs + acqToAction + gpuMs;
+                  const ImVec2 componentsTextPos = ImGui::GetCursorScreenPos();
+                  if (hasSdl)
+                     ImGui::Text("Components: SDL->Act %3.1f  Act->Phys %3.1f  %s %3.1f  Total %3.1f ms", sdlToActMs, acqToAction, gpuLabel, gpuMs, totalMs);
+                  else
+                     ImGui::Text("Components: SDL->Act  -    Act->Phys %3.1f  %s %3.1f  Total  -   ms", acqToAction, gpuLabel, gpuMs);
+                  if (ImGui::IsMouseHoveringRect(componentsTextPos, ImGui::GetCursorScreenPos() + ImVec2(0, ImGui::GetTextLineHeight())))
+                     ImGui::SetTooltip(
+                        "SDL->Act: time from SDL event arrival to VPX action dispatch (input-pipeline queueing)\n"
+                        "Act->Phys: action dispatch to physics flipper rotate (matches the first number above)\n"
+                        "%s: last completed GPU frame length%s\n"
+                        "Total: sum of the three. Does NOT include USB poll staleness or display present + pixel response.",
+                        gpuLabel,
+#ifdef ENABLE_BGFX
+                        " (BGFX gpuTimeBegin/End)"
+#else
+                        " (PROFILE_RENDER_FLIP — CPU-side wait, approximation)"
+#endif
+                     );
+
                   hasFlipperLatency = true;
                   break;
                }

--- a/src/ui/live/ingameui/PointOfViewSettingsPage.cpp
+++ b/src/ui/live/ingameui/PointOfViewSettingsPage.cpp
@@ -11,7 +11,7 @@ namespace VPX::InGameUI
 {
 
 PointOfViewSettingsPage::PointOfViewSettingsPage()
-   : InGameUIPage("Point of View Table Override"s, "Point of view's settings page:\nOptions to override the table's rendering's point of view"s, SaveMode::Table)
+   : InGameUIPage("Point of View Table Override"s, "Point of view's settings page:\nOptions to override the table's rendering's point of view"s, SaveMode::Both)
 {
 }
 
@@ -399,6 +399,101 @@ void PointOfViewSettingsPage::BuildPage()
          BuildPage();
       });
 
+   // Custom Fit-Screen Autofit toggle: "Custom" applies walk-down + max-tilt + sparse-fallback
+   // (fork-local algorithm tuned for landscape cabinets). "Standard" disables those — vanilla
+   // upstream Fit-Screen autofit. Cap and Scale knobs apply in both modes.
+   auto useCustomAutofit = std::make_unique<InGameUIItem>(
+      SelectProp(Settings::m_propTableOverride_ViewDTUseCustomAutofit,
+                 Settings::m_propTableOverride_ViewFSSUseCustomAutofit,
+                 Settings::m_propTableOverride_ViewCabUseCustomAutofit),
+      [this]() {
+         return m_player->m_ptable->m_settings.GetInt(SelectProp(
+            Settings::m_propTableOverride_ViewDTUseCustomAutofit,
+            Settings::m_propTableOverride_ViewFSSUseCustomAutofit,
+            Settings::m_propTableOverride_ViewCabUseCustomAutofit));
+      },
+      [this](int, int v) {
+         m_player->m_ptable->m_settings.Set(SelectProp(
+            Settings::m_propTableOverride_ViewDTUseCustomAutofit,
+            Settings::m_propTableOverride_ViewFSSUseCustomAutofit,
+            Settings::m_propTableOverride_ViewCabUseCustomAutofit), v, false);
+         // Re-run autofit so the new mode takes effect live without reload.
+         if (m_player->m_ptable->GetViewSetup().mMode == VLM_WINDOW && m_player->GetCabinetAutoFitMode() != 0)
+         {
+            m_player->m_ptable->GetViewSetup().SetWindowAutofit(m_player->m_ptable, m_playerPos,
+               m_player->m_renderer->GetDisplayAspectRatio(), m_player->GetCabinetAutoFitPos(),
+               m_player->GetCabinetAutoFitMode() == 2, [](string){});
+         }
+         m_player->m_ptable->GetViewSetup().ApplyTableOverrideSettings(m_player->m_ptable->m_settings, m_player->m_ptable->GetViewMode());
+         const float screenInclination = m_player->m_ptable->m_settings.GetPlayer_ScreenInclination();
+         m_player->m_ptable->GetViewSetup().SetViewPosFromPlayerPosition(m_player->m_ptable, m_playerPos, screenInclination);
+         OnPointOfViewChanged();
+         BuildPage();
+      });
+
+   // Window Top Z Scale — multiplier applied to autofit-computed top glass height. Acts as a
+   // cabinet-wide calibration knob: 0.85 trims every table's top glass by 15% (proportionally),
+   // preserving per-table variation. The multiplier is applied during ApplyTableOverrideSettings
+   // on table load (see ViewSetup.cpp ApplyTableOverrideSettings). During live drag we apply the
+   // change incrementally to mWindowTopZOfs via the (new/prev) ratio — touching ONLY that one
+   // field and leaving every other slider's transient state alone (no autofit re-run).
+   auto wndTopZScale = std::make_unique<InGameUIItem>(
+      SelectProp(Settings::m_propTableOverride_ViewDTWindowTopScale, Settings::m_propTableOverride_ViewFSSWindowTopScale, Settings::m_propTableOverride_ViewCabWindowTopScale),
+      100.f, "%4.1f %%"s,
+      [this]() {
+         return m_player->m_ptable->m_settings.GetFloat(SelectProp(Settings::m_propTableOverride_ViewDTWindowTopScale,
+            Settings::m_propTableOverride_ViewFSSWindowTopScale, Settings::m_propTableOverride_ViewCabWindowTopScale));
+      },
+      [this](float prev, float v)
+      {
+         m_player->m_ptable->m_settings.Set(SelectProp(Settings::m_propTableOverride_ViewDTWindowTopScale,
+            Settings::m_propTableOverride_ViewFSSWindowTopScale, Settings::m_propTableOverride_ViewCabWindowTopScale), v, false);
+         // Incremental ratio: WindowTop_new = WindowTop_now * (v/prev). Only touches the one field.
+         if (prev > 0.f)
+            m_player->m_ptable->GetViewSetup().mWindowTopZOfs *= (v / prev);
+         // Recompute mViewZ — realToVirtual depends on mWindowTopZOfs, so the camera Z drifts
+         // one-directionally on drag without this. Same fix as the WindowTop manual slider.
+         const float screenInclination = m_player->m_ptable->m_settings.GetPlayer_ScreenInclination();
+         m_player->m_ptable->GetViewSetup().SetViewPosFromPlayerPosition(m_player->m_ptable, m_playerPos, screenInclination);
+         OnPointOfViewChanged();
+         BuildPage();
+      });
+
+   // Window Top Z Cap — hard maximum on the autofit-computed top glass height. Clips structural
+   // mesh outliers (e.g. modern remakes that bake a 3D cabinet shell into the playfield mesh)
+   // that push autofit to 20-28 cm when a flat-TV cabinet wants ~7 cm. Set to a high value
+   // (50 cm slider max) to effectively disable. Setter re-runs autofit so the cap takes effect
+   // live in both directions (raising and lowering); only safe in autofit modes where no other
+   // F12 slider has transient unsaved state.
+   auto wndTopZCap = std::make_unique<InGameUIItem>(
+      SelectProp(Settings::m_propTableOverride_ViewDTWindowTopCap, Settings::m_propTableOverride_ViewFSSWindowTopCap, Settings::m_propTableOverride_ViewCabWindowTopCap),
+      VPUTOCM(1.f), "%4.1f cm"s,
+      [this]() {
+         return m_player->m_ptable->m_settings.GetFloat(SelectProp(Settings::m_propTableOverride_ViewDTWindowTopCap,
+            Settings::m_propTableOverride_ViewFSSWindowTopCap, Settings::m_propTableOverride_ViewCabWindowTopCap));
+      },
+      [this](float, float v)
+      {
+         m_player->m_ptable->m_settings.Set(SelectProp(Settings::m_propTableOverride_ViewDTWindowTopCap,
+            Settings::m_propTableOverride_ViewFSSWindowTopCap, Settings::m_propTableOverride_ViewCabWindowTopCap), v, false);
+         // Re-run autofit + apply so cap takes effect both directions. Mirrors Gary's pattern in
+         // Player::SetCabinetAutoFitMode/Pos. Safe in autofit modes (only place this slider is visible).
+         if (m_player->m_ptable->GetViewSetup().mMode == VLM_WINDOW && m_player->GetCabinetAutoFitMode() != 0)
+         {
+            m_player->m_ptable->GetViewSetup().SetWindowAutofit(m_player->m_ptable, m_playerPos,
+               m_player->m_renderer->GetDisplayAspectRatio(), m_player->GetCabinetAutoFitPos(),
+               m_player->GetCabinetAutoFitMode() == 2, [](string){});
+         }
+         m_player->m_ptable->GetViewSetup().ApplyTableOverrideSettings(m_player->m_ptable->m_settings, m_player->m_ptable->GetViewMode());
+         // Recompute mViewZ from the now-capped mWindowBottomZOfs. Without this, mViewZ retains
+         // the autofit-raw value baked in during SetWindowAutofit, so camera position drifts
+         // away from the capped glass plane (visual: table flies/zooms one-directionally on drag).
+         const float screenInclination = m_player->m_ptable->m_settings.GetPlayer_ScreenInclination();
+         m_player->m_ptable->GetViewSetup().SetViewPosFromPlayerPosition(m_player->m_ptable, m_playerPos, screenInclination);
+         OnPointOfViewChanged();
+         BuildPage();
+      });
+
    AddItem(std::move(viewMode));
    switch (viewSetup.mMode)
    {
@@ -442,6 +537,15 @@ void PointOfViewSettingsPage::BuildPage()
                OnPointOfViewChanged();
             BuildPage();
          }));
+      // Visible only when autofit is on — the multiplier calibrates the autofit-computed top
+      // glass height proportionally across all tables. Hidden in Manual mode (where direct
+      // WindowTop slider does the same job).
+      if (m_player->GetCabinetAutoFitMode() != 0)
+      {
+         AddItem(std::move(useCustomAutofit));
+         AddItem(std::move(wndTopZScale));
+         AddItem(std::move(wndTopZCap));
+      }
       if (m_player->GetCabinetAutoFitMode() == 0)
       {
          AddItem(std::move(hOfs));

--- a/src/utils/wintimer.cpp
+++ b/src/utils/wintimer.cpp
@@ -97,6 +97,9 @@ static LARGE_INTEGER sTimerStart = {};
 static LONGLONG OneMSTimerTicks = 0;
 static LONGLONG TwoMSTimerTicks = 0;
 static char highrestimer = 0;
+// SDL3 SDL_GetTicksNS clock starts at SDL init, VPX usec() starts at wintimer_init. Both monotonic but unrelated.
+// Captured once below; usec_at_init - sdl_us_at_init.
+static int64_t sSdlNsToVpxUsOffset = 0;
 
 // call before 1st use of msec,usec or uSleep
 void wintimer_init()
@@ -120,6 +123,19 @@ void wintimer_init()
 
    OneMSTimerTicks = (1000 * TimerFreq.QuadPart) / 1000000ull;
    TwoMSTimerTicks = (2000 * TimerFreq.QuadPart) / 1000000ull;
+
+   // SDL clock vs VPX usec() offset — sampled adjacent so the two reads are within microseconds of each other.
+   const uint64_t sdl_now_ns = SDL_GetTicksNS();
+   const uint64_t vpx_now_us = usec();
+   sSdlNsToVpxUsOffset = static_cast<int64_t>(vpx_now_us) - static_cast<int64_t>(sdl_now_ns / 1000ull);
+}
+
+uint64_t sdl_ns_to_usec(uint64_t sdl_ns)
+{
+   if (sdl_ns == 0)
+      return 0;
+   const int64_t result = static_cast<int64_t>(sdl_ns / 1000ull) + sSdlNsToVpxUsOffset;
+   return result < 0 ? 0 : static_cast<uint64_t>(result);
 }
 
 uint64_t usec()

--- a/src/utils/wintimer.h
+++ b/src/utils/wintimer.h
@@ -23,6 +23,11 @@ void wintimer_init();
 uint32_t msec();
 uint64_t usec();
 
+// Convert an SDL3 nanosecond timestamp (e.g. SDL_Event.common.timestamp, same clock as SDL_GetTicksNS)
+// into the VPX usec() timebase. Backed by a one-time offset captured at wintimer_init.
+// Returns 0 if sdl_ns is 0 (callers use 0 as "no SDL timestamp available").
+uint64_t sdl_ns_to_usec(uint64_t sdl_ns);
+
 // needs timeBeginPeriod(1) before calling 1st time to make the Sleep(1) in here behave more or less accurately (and timeEndPeriod(1) after not needing that precision anymore)
 void uSleep(const uint64_t u);
 


### PR DESCRIPTION
Fork-local Fit-Screen autofit improvements for landscape cabinets, isolated behind a **Custom/Standard** toggle whose defaults are no-ops (Standard == vanilla upstream autofit), so existing tables and other users are unaffected.

## What is in this PR
- **EvaluateGlassHeight** (`pintable.cpp`): walk-down pass over 0.5 cm Z-buckets finds the top of real geometry, skipping phantom 3D-backbox decoration above an air gap; sparse-table fallback to raw max-Z. New `useWalkDown` param.
- **SetWindowAutofit** (`ViewSetup.cpp`): universal 2deg max-tilt clamp (Custom only); sets `mGlassWasEvaluated` to gate the calibration knobs to autofit-derived glass.
- **ApplyTableOverrideSettings** (`ViewSetup.cpp`): `WindowTopScale` (proportional trim) + `WindowTopCap` (absolute ceiling) knobs; skipped in Manual mode.
- **Settings_properties.inl**: DT/FSS/Cab triples for `WindowTopScale`, `WindowTopCap`, `UseCustomAutofit`.
- **PointOfViewSettingsPage**: F12 sliders for the three knobs (autofit modes only); SaveMode Table -> Both.
- **player.cpp**: re-apply overrides + recompute view position after autofit mode/pos changes so the camera stays synced to the capped glass plane.
- **CLAUDE.md**: documents the feature, cabinet ini recovery baseline, and the post-Vincent ViewCabRotation regime.

Also carries 3 small pre-existing branch commits: PerfUI latency line, emulator-slowness docs, SIGFPE guard in the libvpinball progress send.

Verified: Release_BGFX builds clean (0 warnings, 0 errors); deployed to the cabinet and tested through example tables.