### PR TITLE
Ship-back: deploy-vpx skill, build-doc fixes, latency-diagnostics removal

### DIFF
--- a/.claude/skills/debug-vpx/SKILL.md
+++ b/.claude/skills/debug-vpx/SKILL.md
@@ -65,10 +65,9 @@ The "always-attached cdb" stance is the key idea. It costs almost nothing (one e
 
 ### Step 1 (once per session): Build and deploy
 
-Build via **CMake** — the old `create_vs_solution.bat` / VS-solution path is deprecated and no longer compiles merged trees (upstream's import-cleanup broke the PCH; see CLAUDE.md). One-time per clean `build/` dir, copy the BGFX template and configure; after that CMake reconfigures itself on each build:
+Build via **CMake** — the old `create_vs_solution.bat` / VS-solution path is deprecated and no longer compiles merged trees (upstream's import-cleanup broke the PCH; see CLAUDE.md). Upstream ships a single tracked root `CMakeLists.txt` selected by cache vars (the old `make/CMakeLists_<flavor>-*.txt` templates were removed) — configure once per clean `build/` dir; after that CMake reconfigures itself on each build:
 ```powershell
-Copy-Item make\CMakeLists_bgfx-windows-x64.txt CMakeLists.txt -Force
-cmake -G "Visual Studio 17 2022" -A x64 -B build
+cmake -G "Visual Studio 17 2022" -A x64 -B build -DRENDERER=BGFX -DPLATFORM=windows -DARCH=x64
 ```
 
 Debug builds need the **Debug-flavor** prebuilt deps present (download the `dev-third-party-windows-x64-Debug` artifact alongside Release — see CLAUDE.md step 1). Only Debug configs emit the PDBs cdb needs for resolved stacks.

--- a/.claude/skills/deploy-vpx/SKILL.md
+++ b/.claude/skills/deploy-vpx/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: deploy-vpx
+description: Ship the fork's GREEN CI builds to Gary's VPM cabinet — the third leg of the status-vpx -> sync-vpx -> deploy-vpx trilogy. Pulls the 3 windows-x64 Release app exes (BGFX/GL/DX9) from a green fork CI run, verifies each has the real Ball History impl compiled in (not the no-op stub), closes VPX on the cabinet, and copies them to Z:\visual pinball\ as the _BH exes the cabinet actually runs. Use this whenever Gary says "deploy to the VPM", "push the build(s) to the cabinet", "update my VPM/cabinet", "get my cabinet up to date", "ship this to virtualpin", "propagate the fix to GL/DX", "redeploy all renderers", or after a sync-vpx round finishes green and the freshly-built branch needs to land on the cabinet for real play-testing. This is the RELEASE deploy for gameplay — distinct from debug-vpx, which deploys a local Debug build under cdb for the crash/hang inner loop.
+---
+
+# deploy-vpx — ship green CI builds to the VPM cabinet
+
+The trilogy:
+
+```
+status-vpx  (read: where does the branch stack stand?)
+   -> sync-vpx  (advance: rebase master, merge down, rebuild, push, CI green)
+      -> deploy-vpx  (ship: pull the green CI exes onto the cabinet for real play)
+```
+
+`deploy-vpx` is the last leg: it takes a **green** fork CI run and lands its Windows exes on the
+cabinet so Gary can actually play them. It does **not** build anything locally — the CI already
+built (and, on x64, the exes are the same bits CI validated). Its job is: pull the right artifacts,
+prove Ball History is really in them, and copy them onto the cabinet safely.
+
+## deploy-vpx vs debug-vpx — don't confuse them
+
+| | **deploy-vpx** (this skill) | **debug-vpx** |
+|---|---|---|
+| Source | **CI Release artifacts** (green run) | **Local Debug build** (`cmake --build --config Debug`) |
+| What | All 3 renderers: BGFX + GL + DX9 | Usually just BGFX exe + PDB |
+| Where on cabinet | `Z:\visual pinball\*_BH.exe` (the real play exes) | `Z:\Visual Pinball\debug\` (the debug sandbox) |
+| Purpose | Real gameplay / play-test the shipped build | cdb-attached crash/hang/behavior inner loop |
+
+If Gary wants to **debug a crash**, that's debug-vpx. If he wants his **cabinet running the latest
+finished build**, that's deploy-vpx.
+
+## What "up to date" means on the cabinet
+
+The cabinet keeps three renderer builds of the fork, each as an `_BH` exe, plus stock-upstream
+`_orig` backups. The default launcher `VPinballX.exe` is a **symlink** to whichever `_BH` renderer
+is the current default (normally BGFX). deploy-vpx refreshes the three `_BH` exes; it leaves the
+`_orig` backups and the symlink alone unless asked.
+
+| Renderer | CI artifact prefix | exe inside zip | Cabinet deploy name |
+|---|---|---|---|
+| BGFX (default) | `VPinballX_BGFX-…-windows-x64-Release.zip` | `VPinballX_BGFX64.exe` | `VPinballX_BGFX64_BH.exe` |
+| GL | `VPinballX_GL-…-windows-x64-Release.zip` | `VPinballX_GL64.exe` | `VPinballX_GL64_BH.exe` |
+| DX9 | `VPinballX-…-windows-x64-Release.zip` (bare prefix) | `VPinballX64.exe` | `VPinballX64_BH.exe` |
+
+The `_orig` trio (`*_orig.exe`) are stock-upstream fallbacks — a known-good boot path if a fork
+build misbehaves. **Never overwrite `_orig`.**
+
+## Cabinet plumbing (shared with debug-vpx)
+
+Same cabinet, same access as debug-vpx — see `debug-vpx/references/cabinet-setup.md` for the
+one-time provisioning. The essentials:
+
+- Host `virtualpin` (DNS flaky → fallback IP `192.168.1.31`). C$ admin share mapped to `Z:\`.
+- **Always use `Z:\...`** from the dev box (faster + cleaner than UNC). If `Z:` dropped after a
+  cabinet reboot: `net use Z: \\virtualpin\c$ /persistent:yes`.
+- **Close VPX before copying** — a running VPX locks the exe and the copy fails "file in use".
+  Reuse debug-vpx's killer: `paexec \\virtualpin -d cmd /c 'C:\Dumps\preflight-kill.cmd'`.
+- **PAExec, never PsExec**, for any GUI launch on the cabinet (PsExec → black windows).
+- `gh` must be on the **personal** account for fork artifacts: `gh auth switch --user garybrowndev`
+  (the EMU account `gary-brown_bplogix` can't read the fork).
+
+## The deploy round
+
+### Phase 0 — Preflight (always) ⛔ know your source is GREEN
+
+deploy-vpx ships **only** from a green run — a red or still-running build has no trustworthy
+artifacts, and shipping a broken exe means the cabinet won't boot tables. Confirm with Gary:
+
+1. **Which branch/commit?** Normally `integration` (the build/test branch) or `development` after a
+   sync round. A specific `-RunId` if deploying an exact known-green run.
+2. **Is that run green?** The helper below refuses anything not `completed + success`. Never
+   hand-wave this — if CI is still running, wait (watch it per sync-vpx's CI-gating pattern).
+3. **gh account** on `garybrowndev`, **cabinet reachable**, **`Z:` mapped**.
+
+### Phase 1 — Stage + verify (read-only preview)
+
+Run the bundled helper as a **dry run** — it resolves the green run, downloads the three
+windows-x64 Release app exes to a fresh temp dir, verifies each has the real Ball History impl,
+and prints the deploy plan. It copies nothing:
+
+```powershell
+pwsh .claude/skills/deploy-vpx/scripts/deploy-plan.ps1 -Branch integration
+# or a specific run:
+pwsh .claude/skills/deploy-vpx/scripts/deploy-plan.ps1 -RunId 28481960501
+```
+
+**The Ball History verification is load-bearing, not a formality.** Each exe is scanned for the
+`Trainer` / `RunRecord` strings that only exist in the real implementation. When upstream's build
+restructure silently dropped the `__BALLHISTORY_WIN32__` define, every build compiled Ball History
+down to a no-op stub — the exe looked normal until you pressed **V** and nothing happened. The
+script **refuses to deploy a stub** for exactly this reason. If it flags a stub: the fix is in the
+build (confirm `__BALLHISTORY_WIN32__` is defined in `CMakeLists.txt`), not in deploy — stop and
+rebuild.
+
+### Phase 2 — Checkpoint ⛔ review before the copy
+
+Deploying overwrites the exes the cabinet runs — outward-facing and not trivially reversible. Show
+Gary the plan (which run, which three exes, sizes, BH-verified, target paths) and get an explicit
+go, per his standing review-before-ship rule. The dry-run/`-Deploy` split exists to make this
+checkpoint natural.
+
+### Phase 3 — Close VPX + deploy
+
+Close VPX on the cabinet (or the copy fails "file in use"), then deploy. Reuse debug-vpx's
+preflight-kill, then re-run the helper with `-Deploy`:
+
+```powershell
+& 'C:\tools\sysinternals\paexec.exe' \\virtualpin -d cmd /c 'C:\Dumps\preflight-kill.cmd'
+Start-Sleep 4
+pwsh .claude/skills/deploy-vpx/scripts/deploy-plan.ps1 -Branch integration -Deploy
+```
+
+`-Deploy` re-verifies green + BH, then copies each exe to its `_BH` name and prints the landed
+size + timestamp so the copy carries its own receipt.
+
+> If VPX isn't running, the copy just works — preflight-kill is a cheap no-op guard, not mandatory.
+
+### Phase 4 — Confirm + play-test ⛔ the real gate
+
+A copied exe isn't a working exe until Gary runs it. Tell him exactly what to check:
+
+- Launch a table (the default `VPinballX.exe` → BGFX `_BH`; or launch a specific renderer's exe).
+- Press **V** → the Ball History menu should open (confirms BH is really in the build).
+- Navigate the menu with the **flippers** and select with the **plunger/launch** (confirms input
+  works with his actual mapping — keyboard *or* joystick).
+
+Only after Gary confirms is the deploy done. If he wants a **different default renderer**, repoint
+the launcher symlink (it targets the cabinet-local path):
+
+```powershell
+# from the dev box, operating on the cabinet's C: via Z:
+Remove-Item 'Z:\visual pinball\VPinballX.exe' -Force
+New-Item -ItemType SymbolicLink -Path 'Z:\visual pinball\VPinballX.exe' -Target 'C:\Visual Pinball\VPinballX_GL64_BH.exe'
+```
+
+(Target is the cabinet-local `C:\Visual Pinball\...` path, not `Z:\` — the symlink is resolved on
+the cabinet.)
+
+## Common shapes
+
+- **"Deploy the latest integration build"** → Phase 0 confirm green → `deploy-plan.ps1 -Branch integration`
+  (dry run) → review → `-Deploy` → play-test. Usually all three renderers at once.
+- **"Propagate the fix to GL/DX"** → same, all three; the point is closing the gap where BGFX was
+  fixed but GL/DX still ran an older/stubbed build.
+- **"Just BGFX for a quick test"** → you can deploy a single locally-built Release exe by hand
+  (`Copy-Item build\Release\VPinballX_BGFX64.exe 'Z:\visual pinball\VPinballX_BGFX64_BH.exe'`) — but
+  prefer the CI path for anything Gary will keep, so all three stay in lockstep on the same commit.
+
+## Gotchas (earned the hard way)
+
+1. **Never deploy a non-green run.** Red/in-progress artifacts are untrustworthy; a bad exe means
+   the cabinet won't boot tables. The helper enforces this.
+2. **Verify Ball History is compiled in.** A missing `__BALLHISTORY_WIN32__` yields a stub that
+   looks fine until you press V. The `Trainer`/`RunRecord` string check is the guard.
+3. **Close VPX first** or the copy fails "file in use". preflight-kill (from debug-vpx) handles it.
+4. **PAExec `-d -i 1`, never PsExec**, for any GUI launch on the cabinet.
+5. **Don't `Remove-Item` a shared temp/deploy path with a glob** — the sandbox blocks it and a
+   stale glob once matched a live `.ini` and destroyed it. The helper stages into a fresh
+   per-run dir instead.
+6. **`Z:` drops after a cabinet reboot** — remap `net use Z: \\virtualpin\c$ /persistent:yes`.
+7. **gh on the personal account** or fork artifact downloads 401.
+8. **Leave `_orig` alone.** Those are the stock-upstream escape hatch.
+
+## Relationship to the other skills
+
+- **status-vpx** — read-only "where am I"; run it first if unsure whether there's a green build to
+  ship.
+- **sync-vpx** — the branch-advancing round that *produces* the green build deploy-vpx ships. A full
+  session is often `sync-vpx` (ends CI-green) → `deploy-vpx` (lands it on the cabinet).
+- **debug-vpx** — the Debug/cdb inner loop; owns the cabinet plumbing (preflight-kill, PAExec,
+  `cabinet-setup.md`) that this skill reuses. Reach for debug-vpx to *diagnose*, deploy-vpx to
+  *ship*.

--- a/.claude/skills/deploy-vpx/evals/trigger-eval.json
+++ b/.claude/skills/deploy-vpx/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  {"query": "ok the integration CI just went green, get my VPM up to date with it", "should_trigger": true},
+  {"query": "deploy all the release permutations to my cabinet", "should_trigger": true},
+  {"query": "propagate the flipper fix to GL and DX and push them to virtualpin", "should_trigger": true},
+  {"query": "push the latest build to the VPM", "should_trigger": true},
+  {"query": "my cabinet is running an old build, can you update it to the newest development branch", "should_trigger": true},
+  {"query": "ship this to the cabinet so I can play-test it", "should_trigger": true},
+  {"query": "GL and DX9 on the cabinet still have ball history stubbed out — get the fixed builds onto them", "should_trigger": true},
+  {"query": "we just finished the sync round, now land it on virtualpin for real play", "should_trigger": true},
+  {"query": "redeploy all three renderers to Z drive with the _BH names", "should_trigger": true},
+  {"query": "grab the windows-x64 release exes from the green run and copy them to the cabinet", "should_trigger": true},
+  {"query": "VPX crashed on the cabinet when I hit the left flipper, can you attach cdb and find out why", "should_trigger": false},
+  {"query": "let's do a debug cycle on Black Pyramid — I want to watch the trainer state machine", "should_trigger": false},
+  {"query": "run a status check on my repo, where does the branch stack stand", "should_trigger": false},
+  {"query": "sync master with upstream and merge down through integration", "should_trigger": false},
+  {"query": "build the Debug config and deploy it to the debug folder so I can attach the debugger", "should_trigger": false},
+  {"query": "the cabinet hangs after loading a VPinMAME table, dump the threads", "should_trigger": false},
+  {"query": "bundle these three tables into a pinup popper package", "should_trigger": false},
+  {"query": "commit my working changes and open a PR from development to integration", "should_trigger": false},
+  {"query": "why is CI red on the x86 debug job", "should_trigger": false},
+  {"query": "remap my Z drive to the cabinet, it dropped after a reboot", "should_trigger": false}
+]

--- a/.claude/skills/deploy-vpx/scripts/deploy-plan.ps1
+++ b/.claude/skills/deploy-vpx/scripts/deploy-plan.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+  Resolve a GREEN fork CI run, pull the 3 windows-x64 Release app exes (BGFX / GL / DX9),
+  verify each actually contains the real Ball History implementation (not the no-op stub),
+  and print a deploy plan for the VPM cabinet.
+
+.DESCRIPTION
+  This is the read-only "preview" for deploy-vpx (the analogue of status-vpx's status.sh and
+  sync-vpx's sync-plan.sh). Without -Deploy it touches nothing on the cabinet: it only resolves
+  the run, downloads + stages the artifacts, verifies Ball History is compiled in, and prints the
+  src->dst mapping. Review that plan, then re-run with -Deploy to perform the copy (after closing
+  VPX on the cabinet — see the SKILL.md checkpoint).
+
+  Deploying is outward-facing and hard to undo (it overwrites the exe the cabinet runs), so the
+  two-step "plan then -Deploy" split is deliberate: it gives Gary a checkpoint to review before
+  anything on the cabinet changes.
+
+.PARAMETER Branch
+  Branch whose latest GREEN run to deploy (default: integration — the build/test branch).
+  Ignored if -RunId is given.
+
+.PARAMETER RunId
+  Deploy a specific CI run instead of the latest green run on -Branch. The script still refuses
+  to proceed unless that run's conclusion is 'success'.
+
+.PARAMETER Deploy
+  Actually copy the staged exes to the cabinet. Omit for a dry-run plan (the safe default).
+
+.PARAMETER Repo
+  Fork repo (default: garybrowndev/vpinball). gh must be authed on the personal account —
+  the EMU account (gary-brown_bplogix) can't read the fork.
+
+.PARAMETER CabinetDir
+  Cabinet deploy folder as seen from the dev box (default: 'Z:\visual pinball').
+
+.EXAMPLE
+  ./deploy-plan.ps1 -Branch integration            # dry-run: stage + verify + print plan
+.EXAMPLE
+  ./deploy-plan.ps1 -Branch integration -Deploy     # perform the copy after reviewing
+.EXAMPLE
+  ./deploy-plan.ps1 -RunId 28481960501 -Deploy       # deploy a specific known-green run
+#>
+param(
+  [string]$Branch = 'integration',
+  [string]$RunId,
+  [switch]$Deploy,
+  [string]$Repo = 'garybrowndev/vpinball',
+  [string]$CabinetDir = 'Z:\visual pinball'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Info($m) { Write-Host $m }
+function Warn($m) { Write-Host "WARN: $m" -ForegroundColor Yellow }
+function Die($m)  { Write-Host "ERROR: $m" -ForegroundColor Red; exit 1 }
+
+# --- gh account check (fork reads need the personal account) ------------------------------------
+$acct = (gh auth status 2>&1 | Select-String 'Active account: true' -Context 1,0).Context.PreContext
+if ($acct -and ($acct -join ' ') -notmatch 'garybrowndev') {
+  Warn "gh active account is not garybrowndev — fork artifact download may 401. Run: gh auth switch --user garybrowndev"
+}
+
+# --- Resolve the run --------------------------------------------------------------------------
+if (-not $RunId) {
+  Info "Resolving latest GREEN run on '$Branch'..."
+  $run = gh run list --repo $Repo --branch $Branch --limit 15 `
+           --json databaseId,headSha,status,conclusion,workflowName,createdAt |
+         ConvertFrom-Json |
+         Where-Object { $_.status -eq 'completed' -and $_.conclusion -eq 'success' } |
+         Select-Object -First 1
+  if (-not $run) { Die "No completed+green run found on '$Branch'. Is CI still running, or red? (deploy-vpx never ships a non-green build.)" }
+  $RunId = $run.databaseId
+  Info "  -> run $RunId ($($run.headSha.Substring(0,9)), $($run.workflowName))"
+} else {
+  $run = gh run view $RunId --repo $Repo --json databaseId,headSha,status,conclusion,workflowName | ConvertFrom-Json
+  if ($run.status -ne 'completed' -or $run.conclusion -ne 'success') {
+    Die "Run $RunId is status=$($run.status) conclusion=$($run.conclusion) — refusing. deploy-vpx only ships GREEN runs (its artifacts + build are only trustworthy once the run succeeds)."
+  }
+  Info "Using run $RunId ($($run.headSha.Substring(0,9))) — verified GREEN."
+}
+$sha = $run.headSha.Substring(0,9)
+
+# --- Enumerate the 3 windows-x64 Release app artifacts ----------------------------------------
+# DX9 prefix 'VPinballX-<digit>' (bare); BGFX 'VPinballX_BGFX-'; GL 'VPinballX_GL-'. Exclude deps.
+$allArts = (gh api "repos/$Repo/actions/runs/$RunId/artifacts" --paginate -q '.artifacts[].name' 2>$null) -split "`n" | Where-Object { $_ }
+$want = @(
+  @{ key='DX9';  pat='^VPinballX-\d.*windows-x64-Release\.zip$';   exe='VPinballX64.exe';      dst='VPinballX64_BH.exe' },
+  @{ key='BGFX'; pat='^VPinballX_BGFX-.*windows-x64-Release\.zip$'; exe='VPinballX_BGFX64.exe'; dst='VPinballX_BGFX64_BH.exe' },
+  @{ key='GL';   pat='^VPinballX_GL-.*windows-x64-Release\.zip$';   exe='VPinballX_GL64.exe';   dst='VPinballX_GL64_BH.exe' }
+)
+foreach ($w in $want) {
+  $w.artifact = $allArts | Where-Object { $_ -match $w.pat } | Select-Object -First 1
+  if (-not $w.artifact) { Die "Could not find the $($w.key) windows-x64-Release artifact on run $RunId. Artifacts present:`n  $($allArts -join "`n  ")" }
+}
+
+# --- Download to a FRESH temp dir (never Remove-Item a shared path — the sandbox blocks it,
+#     and a stale-dir glob once destroyed a live file; see CLAUDE.md) ---------------------------
+$stage = Join-Path $env:TEMP "vpx-deploy-$RunId"
+if (-not (Test-Path $stage)) { New-Item -ItemType Directory -Force $stage | Out-Null }
+foreach ($w in $want) {
+  $outDir = Join-Path $stage $w.key
+  if (-not (Test-Path (Join-Path $outDir $w.exe))) {
+    Info "downloading $($w.key): $($w.artifact) ..."
+    gh run download $RunId --repo $Repo -n $w.artifact --dir $outDir 2>&1 | Out-Null
+  }
+  $found = Get-ChildItem $outDir -Recurse -Filter $w.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $found) { Die "Artifact $($w.artifact) did not contain $($w.exe)." }
+  $w.src = $found.FullName
+}
+
+# --- Verify the real Ball History impl is compiled in (stub lacks these strings) ---------------
+# This is the load-bearing safety net: the stub compiles when __BALLHISTORY_WIN32__ is missing
+# (as happened when upstream's build restructure dropped the define), and a stubbed exe looks
+# fine until you press V and nothing happens. Refuse to deploy a stub.
+foreach ($w in $want) {
+  $txt = [System.Text.Encoding]::ASCII.GetString([System.IO.File]::ReadAllBytes($w.src))
+  $w.hasBH = ($txt -match 'Trainer' -and $txt -match 'RunRecord')
+  $w.mb    = [math]::Round((Get-Item $w.src).Length/1MB,1)
+}
+
+# --- Print the plan ---------------------------------------------------------------------------
+Info ""
+Info "=== Deploy plan (run $RunId @ $sha -> $CabinetDir) ==="
+$want | ForEach-Object {
+  "{0,-5} {1,-22} {2,6} MB  BH={3,-5} -> {4}" -f $_.key, $_.exe, $_.mb, $_.hasBH, (Join-Path $CabinetDir $_.dst)
+} | ForEach-Object { Info $_ }
+
+$stub = $want | Where-Object { -not $_.hasBH }
+if ($stub) { Die "$($stub.key -join ', ') exe(s) have Ball History STUBBED OUT (no Trainer/RunRecord). Do NOT deploy — check __BALLHISTORY_WIN32__ is defined in CMakeLists.txt and rebuild. See CLAUDE.md." }
+
+# --- Cabinet reachability ----------------------------------------------------------------------
+$reachable = Test-Connection -TargetName virtualpin -Count 1 -Quiet -ErrorAction SilentlyContinue
+$zmapped   = Test-Path $CabinetDir
+Info ""
+Info "cabinet 'virtualpin' reachable: $reachable ; '$CabinetDir' mapped: $zmapped"
+if (-not $zmapped) { Warn "Z: not mapped. Remap: net use Z: \\virtualpin\c$ /persistent:yes  (fallback host: 192.168.1.31)" }
+
+if (-not $Deploy) {
+  Info ""
+  Info "DRY RUN — nothing copied. Review the plan above, then re-run with -Deploy (close VPX on the cabinet first)."
+  return
+}
+
+# --- Deploy (only with -Deploy) ---------------------------------------------------------------
+if (-not $reachable) { Die "Cabinet not reachable — cannot deploy." }
+if (-not $zmapped)   { Die "$CabinetDir not mapped — cannot deploy." }
+Info ""
+Info "=== Deploying (VPX must be closed on the cabinet or the copy fails 'file in use') ==="
+foreach ($w in $want) {
+  $dst = Join-Path $CabinetDir $w.dst
+  Copy-Item $w.src $dst -Force -ErrorAction Stop
+  $now = Get-Item $dst
+  Info "  {0,-5} -> {1}  ({2} MB, {3})" -f $w.key, $dst, [math]::Round($now.Length/1MB,1), $now.LastWriteTime
+}
+Info ""
+Info "Deployed. Default launcher (VPinballX.exe symlink) points at whatever renderer it was set to;"
+Info "have Gary launch a table and confirm Ball History (press V) + flipper menu nav work."

--- a/.claude/skills/sync-vpx/SKILL.md
+++ b/.claude/skills/sync-vpx/SKILL.md
@@ -157,8 +157,7 @@ deps** (upstream's won't — the merged tree has different dep SHAs).
 2. **Build via CMake** (NOT `create_vs_solution.bat` — that path is deprecated/broken;
    see CLAUDE.md). Cap parallelism at `/m:9` on Gary's 12-core laptop to avoid C1076:
    ```powershell
-   Copy-Item make\CMakeLists_bgfx-windows-x64.txt CMakeLists.txt -Force
-   cmake -G "Visual Studio 17 2022" -A x64 -B build           # reconfigures itself after first run
+   cmake -G "Visual Studio 17 2022" -A x64 -B build -DRENDERER=BGFX -DPLATFORM=windows -DARCH=x64  # single tracked root CMakeLists; no template copy. Reconfigures itself after first run
    cmake --build build --config Release -- /m:9 /p:CL_MPCount=9
    ```
    Output: `build/Release/VPinballX_BGFX64.exe`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,30 +22,35 @@ Upstream builds Windows via **CMake** (`cmake -G "Visual Studio …" && cmake --
    robocopy "$env:TEMP\vpx-deps\runtime-libs" third-party\runtime-libs /E
    git checkout -- third-party/   # revert tracked-file changes; gitignored binaries keep the fresh versions
    ```
-2. **Copy the CMake template to the repo root** (re-do if you switch flavor, e.g. GL):
+2. **Configure** (one-time per clean build dir; reconfigures automatically after that). Upstream now
+   ships a **single tracked root `CMakeLists.txt`** selected by cache vars — there is **no template to
+   copy** (the old `make/CMakeLists_<flavor>-<platform>-<arch>.txt` files were **removed upstream**; only
+   the per-plugin `make/CMakeLists_plugin_*.txt` and `make/CMakeLists_sources.txt` remain):
    ```powershell
-   Copy-Item make\CMakeLists_bgfx-windows-x64.txt CMakeLists.txt -Force
+   cmake -G "Visual Studio 17 2022" -A x64 -B build -DRENDERER=BGFX -DPLATFORM=windows -DARCH=x64
    ```
-3. **Configure** (one-time per clean build dir; reconfigures automatically after that):
-   ```powershell
-   cmake -G "Visual Studio 17 2022" -A x64 -B build
-   ```
-4. **Build** (cap file-parallelism to avoid C1076 heap errors):
+   - `RENDERER` = `BGFX` (default) | `GL` | `DX9`. `PLATFORM`/`ARCH` auto-detect from the host, so on a
+     Windows x64 box `cmake -G "Visual Studio 17 2022" -A x64 -B build` alone yields a BGFX build — but
+     passing the vars explicitly is clearer and is **required** to select GL/DX9.
+   - Switch renderer by configuring a **separate build dir** with a different `-DRENDERER` (e.g.
+     `-B buildgl -DRENDERER=GL`) — no file copy, no repo-root mutation.
+3. **Build** (cap file-parallelism to avoid C1076 heap errors):
    ```powershell
    cmake --build build --config Release -- /m:9 /p:CL_MPCount=9                       # full: vpx + all plugins
    cmake --build build --config Release --target vpinball -- /m:9 /p:CL_MPCount=9      # just the exe (faster; skips plugin post-build DLL copies)
    ```
-   Output: **`build/Release/VPinballX_BGFX64.exe`** (CMake `RUNTIME_OUTPUT_NAME`); plugins land in `build/Release/plugins/`.
+   Output exe by renderer (CMake `RUNTIME_OUTPUT_NAME`): **BGFX → `build/Release/VPinballX_BGFX64.exe`**,
+   GL → `VPinballX_GL64.exe`, DX9 → `VPinballX64.exe`; plugins land in `build/Release/plugins/`.
 
 - **Deploy convention**: `build/Release/VPinballX_BGFX64.exe` → cabinet `Z:\visual pinball\VPinballX_BGFX64_BH.exe` (rename adds `_BH`). **Close VPX on the cabinet first** or the copy fails with "file in use".
-- **After an upstream merge**: re-download fresh `dev-third-party` deps (versions bump) and re-`Copy-Item` the CMakeLists; CMake reconfigures itself — no `create_vs_solution.bat`. If a plugin post-build fails on a missing DLL (e.g. `libserialport64-0.dll`), your deps are stale → refresh them.
+- **After an upstream merge**: re-download fresh `dev-third-party` deps (versions bump); CMake reconfigures itself from the tracked root `CMakeLists.txt` — no template copy, no `create_vs_solution.bat`. If a plugin post-build fails on a missing DLL (e.g. `libserialport64-0.dll`), your deps are stale → refresh them.
 - **Never run `platforms/windows-x64/external.sh`** unless rebuilding all 12 deps from source: it needs **VS2026 + MSYS2 (`/c/msys64` UCRT64) + nasm**. The prebuilt-deps download replaces it.
 
 ### Build tips (CMake)
 - **Header changes rebuild automatically** — CMake/MSBuild tracks header dependencies, so the old VS-solution "delete all `.obj`" ritual isn't needed. For a fully clean build, delete the `build/` dir and re-run the configure step.
 - **Build just the exe** (faster; also dodges plugin post-build DLL-copy failures when deps are slightly stale): `cmake --build build --config Release --target vpinball -- /m:9 /p:CL_MPCount=9`. The cabinet keeps its existing plugins.
 - **Cap file parallelism** with `/p:CL_MPCount=9` (75% of 12 cores) to avoid C1076 heap-limit errors (`/m:9` caps project-level parallelism).
-- **GL instead of BGFX**: `Copy-Item make\CMakeLists_gl-windows-x64.txt CMakeLists.txt`, then configure into a separate `build` dir.
+- **GL/DX9 instead of BGFX**: configure a separate build dir with `-DRENDERER=GL` (or `DX9`), e.g. `cmake -G "Visual Studio 17 2022" -A x64 -B buildgl -DRENDERER=GL -DPLATFORM=windows -DARCH=x64`. Caveat: VS2022 builds **BGFX** cleanly, but **GL/DX9 may fail locally with DXGI header errors** — CI (VS2026 generator) builds them fine, so pull the GL/DX exes from a green CI run (see `deploy-vpx`) rather than fighting the local toolchain.
 - **Fork vs upstream deps**: on pure `master` the `dev-third-party` zips from `vpinball/vpinball` match; on `integration`/`development` (Ball History + upstream merged) only **our fork's** run for that commit has matching dep SHAs — pull from `garybrowndev/vpinball` (CMake build, step 1).
 - **gh account**: writes/artifact pulls on the fork need the personal account active — `gh auth switch --user garybrowndev` (the `gary-brown_bplogix` EMU account can't access `garybrowndev/vpinball`).
 

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -1464,12 +1464,6 @@ void Player::LockForegroundWindow(const bool enable)
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-// DIAGNOSTIC: input-pump cadence probe. g_diagLastPumpGapUs = wall-clock interval between consecutive main-thread
-// ProcessOSMessages calls. InputAction stamps it at flip time so PerfUI's CSV reveals whether SDL->Act latency comes
-// from infrequent pumping (thread blocked -> large gap) or late SDL delivery (frequent pumping -> small gap).
-uint64_t g_diagLastPumpEntryUs = 0;
-uint64_t g_diagLastPumpGapUs = 0;
-
 void Player::ProcessOSMessages(const bool isInitialized)
 {
    // SDL_PollEvent is main-thread only. SubmitRenderFrame (BGFX) intentionally calls
@@ -1484,10 +1478,6 @@ void Player::ProcessOSMessages(const bool isInitialized)
    // deref a null ImGui context or dangling m_liveUI. Matches the isInitialized=false path.
    const bool dispatch = isInitialized && (m_closing != CS_CLOSED);
    const uint64_t startTick = usec();
-   // DIAGNOSTIC: interval since the previous main-thread pump (input-pump cadence probe).
-   if (g_diagLastPumpEntryUs != 0)
-      g_diagLastPumpGapUs = startTick - g_diagLastPumpEntryUs;
-   g_diagLastPumpEntryUs = startTick;
    SDL_Event e;
    bool isPFWnd = true;
    static Vertex2D dragStart;

--- a/src/input/InputAction.cpp
+++ b/src/input/InputAction.cpp
@@ -5,9 +5,6 @@
 
 #include <sstream>
 
-// DIAGNOSTIC: input-pump cadence probe (defined in player.cpp); stamped at flip time below.
-extern uint64_t g_diagLastPumpGapUs;
-
 
 void InputAction::ClearMapping()
 {
@@ -254,8 +251,6 @@ void InputAction::OnInputChanged(ButtonMapping* mapping)
       // m_sdlArrivalUs stays 0 in that case and PerfUI shows '-'.
       m_sdlArrivalUs = mapping ? mapping->GetLastChangeArrivalUs() : 0;
       m_lastOnChangeUs = usec();
-      m_sdlNowAtChangeUs = sdl_ns_to_usec(SDL_GetTicksNS()); // DIAGNOSTIC: SDL clock sampled adjacent to usec() for cross-check
-      m_pumpGapUs = g_diagLastPumpGapUs; // DIAGNOSTIC: input-pump cadence (interval since previous pump) at this flip
       if (m_eventManager->OnInputActionStateChanged(this))
          m_onStateChange(*this, wasPressed, m_isPressed);
       if (m_isPressed && m_repeatPeriodUs >= 0)

--- a/src/input/InputAction.h
+++ b/src/input/InputAction.h
@@ -40,13 +40,6 @@ public:
    // SDL event arrival time (in VPX usec()) for the mapping that caused the most recent state change. 0 if unknown
    // (e.g. direct-state path with no SDL origin, or pre-event startup).
    uint64_t GetSdlArrival() const { return m_sdlArrivalUs; }
-   // DIAGNOSTIC: the SDL clock (converted to usec() timebase) sampled at the same instant as m_lastOnChangeUs.
-   // Lets PerfUI cross-check the clock conversion (should equal m_lastOnChangeUs within microseconds) and tell
-   // whether SDL stamps events at hardware-arrival vs pump-time (m_sdlNowAtChangeUs - m_sdlArrivalUs == real queue delay).
-   uint64_t GetSdlNowAtChange() const { return m_sdlNowAtChangeUs; }
-   // DIAGNOSTIC: wall-clock interval since the previous input pump, captured at the most recent state change.
-   // Small (~sub-ms) => pumps run often (delay is upstream in SDL/OS delivery); large (~frame) => thread was blocked.
-   uint64_t GetPumpGap() const { return m_pumpGapUs; }
 
    void SetActionId(unsigned int id) { m_actionId = id; }
    unsigned int GetActionId() const { return m_actionId; }
@@ -74,8 +67,6 @@ private:
    bool m_isPressed = false;
    uint64_t m_lastOnChangeUs = 0;
    uint64_t m_sdlArrivalUs = 0;
-   uint64_t m_sdlNowAtChangeUs = 0; // DIAGNOSTIC: SDL clock (usec() base) sampled alongside m_lastOnChangeUs
-   uint64_t m_pumpGapUs = 0; // DIAGNOSTIC: interval since previous input pump, captured at the last state change
    int64_t m_repeatPeriodUs = -1;
    unsigned int m_actionId = 0xFFFFFFFF;
 };

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -14,7 +14,6 @@
 
 #include "ScanCodes.h"
 
-#include <fstream> // DIAGNOSTIC: per-event input delivery latency CSV
 
 #ifdef __LIBVPINBALL__
    #include "lib/src/VPinballLib.h"
@@ -531,35 +530,6 @@ void InputManager::ProcessInput()
 
 void InputManager::HandleSDLEvent(const SDL_Event& e) { m_sdlHandler->HandleSDLEvent(e); }
 
-// DIAGNOSTIC: append per-event input delivery latency (SDL event timestamp -> VPX dispatch), tagged by device, to
-// <exe-dir>/input_delivery.csv. A single arcade-button press fires BOTH a joystick button event and (via JoyToKey)
-// a keyboard event, so this records both for the same press -> direct keyboard(WM_KEYDOWN) vs joystick(HID) comparison.
-static void LogInputDelivery(uint16_t deviceId, uint16_t buttonId, bool isKeyboard, int64_t deliveryUs)
-{
-   static string s_path;
-   static bool s_resolved = false;
-   if (!s_resolved)
-   {
-      char p[MAX_PATH] = {};
-      GetModuleFileNameA(nullptr, p, MAX_PATH);
-      const string s(p);
-      const size_t sl = s.find_last_of("\\/");
-      s_path = (sl == string::npos ? string() : s.substr(0, sl + 1)) + "input_delivery.csv";
-      s_resolved = true;
-   }
-   static bool s_hdr = false;
-   static uint64_t s_idx = 0;
-   std::ofstream f(s_path, s_hdr ? std::ios::app : std::ios::trunc);
-   if (!f)
-      return;
-   if (!s_hdr)
-   {
-      f << "idx,deviceId,isKeyboard,buttonId,delivery_us,delivery_ms\n";
-      s_hdr = true;
-   }
-   f << s_idx++ << ',' << deviceId << ',' << (isKeyboard ? 1 : 0) << ',' << buttonId << ',' << deliveryUs << ',' << (1e-3 * static_cast<double>(deliveryUs)) << '\n';
-}
-
 void InputManager::PushButtonEvent(uint16_t deviceId, uint16_t buttonId, uint64_t timestampNs, bool isPressed)
 {
    // Discard keyboard events when the UI is capturing the keyboard (e.g. for control input)
@@ -570,10 +540,6 @@ void InputManager::PushButtonEvent(uint16_t deviceId, uint16_t buttonId, uint64_
    // OpenPinDev callers pass a firmware clock (not SDL) — converted value is meaningless for that path,
    // but it's a debug-only display and OpenPinDev isn't Gary's primary input route.
    const uint64_t sdlArrivalUs = sdl_ns_to_usec(timestampNs);
-
-   // DIAGNOSTIC: record delivery latency for each button-down (keyboard vs joystick path comparison).
-   if (isPressed && timestampNs != 0)
-      LogInputDelivery(deviceId, buttonId, deviceId == m_keyboardDeviceId, static_cast<int64_t>(usec()) - static_cast<int64_t>(sdlArrivalUs));
 
    uint32_t id = deviceId << 16 | buttonId;
    if (auto it = m_buttonMappings.find(id); it != m_buttonMappings.end())

--- a/src/ui/live/PerfUI.cpp
+++ b/src/ui/live/PerfUI.cpp
@@ -13,7 +13,6 @@
 #include "imgui/imgui_internal.h"
 #include "implot/implot.h"
 
-#include <fstream> // DIAGNOSTIC: latency CSV logging
 
 
 PerfUI::PerfUI(Player *const player)
@@ -154,10 +153,6 @@ void PerfUI::RenderFPS()
                   m_flipLatchTotalMs = m_flipLatchSdlToActMs + m_flipLatchAcqToAction + m_flipLatchGpuMs;
                   m_flipLatchCapturedLeftChange = lastLeftFlipChange; // mark this press captured (refresh on next press)
                   m_flipLatchActive = true;
-
-                  // DIAGNOSTIC: one CSV row per press to validate SDL->Act / the clock conversion.
-                  LogLatencyDiag(sdlArrivalUs, lastLeftFlipChange, leftAction->GetSdlNowAtChange(), flipper->GetLastRotateTime(),
-                     m_flipLatchGpuMs, 1e-3 * static_cast<double>(m_player->m_renderProfiler->GetPrev(FrameProfiler::PROFILE_FRAME)), m_flipLatchHasSdl, leftAction->GetPumpGap());
                   break;
                }
             }
@@ -208,44 +203,6 @@ void PerfUI::RenderFPS()
       ImGui::PopStyleVar();
 
    ImGui::End();
-}
-
-void PerfUI::LogLatencyDiag(uint64_t sdlArrivalUs, uint64_t dispatchUs, uint64_t sdlNowUs, uint64_t rotateUs, double gpuMs, double frameMs, bool hasSdl, uint64_t pumpGapUs)
-{
-   // Resolve <exe-dir>/perfui_latency.csv once. On the cabinet that is C:\visual pinball\ (== Z:\visual pinball\ from dev).
-   static string s_csvPath;
-   static bool s_resolved = false;
-   if (!s_resolved)
-   {
-      char exePath[MAX_PATH] = {};
-      GetModuleFileNameA(nullptr, exePath, MAX_PATH);
-      const string p(exePath);
-      const size_t slash = p.find_last_of("\\/");
-      s_csvPath = (slash == string::npos ? string() : p.substr(0, slash + 1)) + "perfui_latency.csv";
-      s_resolved = true;
-   }
-
-   // Truncate (and write header) on the first row of the session, then append.
-   static bool s_headerWritten = false;
-   static uint64_t s_idx = 0;
-   std::ofstream f(s_csvPath, s_headerWritten ? std::ios::app : std::ios::trunc);
-   if (!f)
-      return;
-   if (!s_headerWritten)
-   {
-      f << "idx,A_sdlArrival_us,B_dispatch_us,C_sdlNow_us,rotate_us,skew_BminusC_us,sdlElapsed_CminusA_us,SDLtoAct_ms,ActToPhys_ms,GPU_ms,frame_ms,hasSdl,pumpGap_us\n";
-      s_headerWritten = true;
-   }
-
-   // skew_BminusC: clock-soundness (usec() vs SDL clock at the same instant — should be ~0 if both QPC-backed).
-   // sdlElapsed_CminusA: arrival->pump delay measured purely in the SDL clock (if ~= SDLtoAct, the conversion is sound;
-   //                     if it is large, SDL preserved an earlier hardware-arrival timestamp -> the latency is real).
-   const int64_t skew = static_cast<int64_t>(dispatchUs) - static_cast<int64_t>(sdlNowUs);
-   const int64_t sdlElapsed = static_cast<int64_t>(sdlNowUs) - static_cast<int64_t>(sdlArrivalUs);
-   const double sdlToActMs = 1e-3 * static_cast<double>(static_cast<int64_t>(dispatchUs) - static_cast<int64_t>(sdlArrivalUs));
-   const double actToPhysMs = 1e-3 * static_cast<double>(static_cast<int64_t>(rotateUs) - static_cast<int64_t>(dispatchUs));
-   f << s_idx++ << ',' << sdlArrivalUs << ',' << dispatchUs << ',' << sdlNowUs << ',' << rotateUs << ',' << skew << ',' << sdlElapsed << ',' << sdlToActMs << ',' << actToPhysMs << ','
-     << gpuMs << ',' << frameMs << ',' << (hasSdl ? 1 : 0) << ',' << pumpGapUs << '\n';
 }
 
 void PerfUI::RenderStats() const

--- a/src/ui/live/PerfUI.h
+++ b/src/ui/live/PerfUI.h
@@ -30,10 +30,6 @@ private:
    void RenderStats() const;
    void RenderPlots();
 
-   // DIAGNOSTIC: append one CSV row per latched LEFT-flipper press to <exe-dir>/perfui_latency.csv, for validating
-   // that SDL->Act / the clock conversion are sound. Truncates the file on the first call of the session.
-   void LogLatencyDiag(uint64_t sdlArrivalUs, uint64_t dispatchUs, uint64_t sdlNowUs, uint64_t rotateUs, double gpuMs, double frameMs, bool hasSdl, uint64_t pumpGapUs);
-
    Player* const m_player;
    float m_uiScale = 1.0f;
 


### PR DESCRIPTION
Ships the development-branch work up to integration:

- **deploy-vpx skill** (`fc7b0428b`) — completes the status-vpx -> sync-vpx -> deploy-vpx trilogy.
- **Build-doc fixes** (`3cc18d23f`, `59d252651`) — CLAUDE.md + debug-vpx/sync-vpx SKILL.md corrected for
  upstream's single-root-CMakeLists flow (`-DRENDERER/-DPLATFORM/-DARCH`; the old template-copy step
  referenced a deleted file).
- **Latency-diagnostics removal** (`b8287d095`) — pure 105-line deletion of the settled SDL->Act
  investigation instrumentation (CSV writers, pump-cadence probe, diagnostic getters). Preserves the
  PerfUI latch / Input-Latency / Components overlay and the m_sdlArrivalUs/m_lastOnChangeUs plumbing.

NOTE: the `arlock_*.txt` writes were intentionally NOT removed — they are aspect-ratio-lock
persistence (a real feature), not a diagnostic.